### PR TITLE
9 mocking library

### DIFF
--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -1,0 +1,41 @@
+# AI-assisted development
+
+Using a large language model (LLM) or similar assistant to draft patches, explore refactors, or write tests for this repository is **fine**. The maintainer and reviewers still need a **human** who stands behind the work: **assistants are tools, not authors.**
+
+The expectations below are our project rules, written in the same spirit as the Linux kernel’s [`Documentation/process/coding-assistants.rst`](https://raw.githubusercontent.com/torvalds/linux/refs/heads/master/Documentation/process/coding-assistants.rst), adapted here for this **MIT**-licensed Rust crate and a typical GitHub PR workflow.
+
+## Expectations
+
+**Follow the normal process.** AI-assisted changes should go through the same path as any other contribution: project conventions, code style, and how pull requests are described and reviewed. Use the README, existing code, and any contributor docs as the source of truth.
+
+**Understand the change and be able to justify it.** You should grasp every meaningful part of what you submit—behavior, tradeoffs, and how it fits the design. Reviewers may ask *why* something was done; answers like “the model suggested it” are not enough. Tie decisions to project goals: correctness, API stability, performance, clarity, or maintenance cost. If you cannot explain it in review, read and simplify before opening a PR.
+
+**You certify the contribution.** Only a **human** can certify the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) where your workflow uses `Signed-off-by` or equivalent. **AI agents must not add `Signed-off-by` lines.** You are responsible for reviewing all AI-generated code, ensuring it meets licensing and project rules, and taking **full responsibility** for the submission. Do not let tooling imply that an automated system signed off on behalf of a person.
+
+**Avoid unnecessary complexity.** LLMs often add more abstraction, indirection, or generality than the task needs; that makes changes easier to **question, rewrite, or reject** in review. Prefer the smallest change that solves the problem and matches surrounding style.
+
+**Verify locally.** Run tests, `clippy`, and formatting as appropriate. Generated code can compile and still be wrong or brittle.
+
+**Licensing.** Contributions must comply with this repository’s license (see [`LICENSE`](LICENSE)). Do not submit code you are not allowed to distribute under those terms. When in doubt, ask before opening a PR.
+
+## Optional attribution (`Assisted-by`)
+
+You may document how a change was produced with an **`Assisted-by`** line in a commit message or PR description:
+
+```text
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+
+* `AGENT_NAME` — assistant or product name.  
+* `MODEL_VERSION` — specific model or version.  
+* `[TOOL1] [TOOL2]` — optional **specialized** tools (e.g. linters, codemods) relevant to the change.
+
+Do **not** list ordinary tools such as git, `rustc`, `cargo`, or editors.
+
+Example:
+
+```text
+Assisted-by: ExampleAssistant:model-2025-01 clippy rustfmt
+```
+
+Attribution is optional unless maintainers ask for it on a given change.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "suitecase"
 version = "0.0.4"
 dependencies = [
+ "serde_json",
  "sqlx",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ license = "MIT"
 [dependencies]
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "migrate"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 **Heavy development:** The API is still evolving. Expect **breaking changes** between releases until a stable 1.0; pin an exact version (or git revision) in `Cargo.toml` if you need upgrades to be predictable.
 
-**Install · [Usage](#usage) · [Examples](#examples) · [Docs](https://docs.rs/suitecase)** (after publish; `cargo doc --open` locally)
+**Install · [Usage](#usage) · [Assertions](#assertions-assert) · [Mocking](#mocking-mock) · [Examples](#examples) · [Docs](https://docs.rs/suitecase)** (after publish; `cargo doc --open` locally)
 
 ---
 
 - **Sync runner** — [`run`](https://docs.rs/suitecase/latest/suitecase/suite/fn.run.html) orchestrates hooks and case bodies; integrate async I/O with something like `tokio::runtime::Handle::block_on` in hooks or cases.
 - **Hooks as optional fns** — [`HookFns`](https://docs.rs/suitecase/latest/suitecase/suite/struct.HookFns.html) holds `Option<fn(&mut S)>` per lifecycle slot; use [`None`] to skip.
 - **Macros** — [`cases!`](https://docs.rs/suitecase/latest/suitecase/macro.cases.html) builds `&'static [Case<S>]`. [`test_suite!`](https://docs.rs/suitecase/latest/suitecase/macro.test_suite.html) emits one `#[test]` per case name; each run uses [`RunConfig::filter`](https://docs.rs/suitecase/latest/suitecase/suite/struct.RunConfig.html#method.filter) and the **same** shared suite (see macro docs for `Send` and ordering).
+- **Assertions** — [`suitecase::assert`](https://docs.rs/suitecase/latest/suitecase/assert/index.html) provides [testify/assert](https://pkg.go.dev/github.com/stretchr/testify/assert)-style helpers (`equal`, `contains`, `assert_ok`, …) that **panic** on failure with clear messages ([`#[track_caller]`](https://doc.rust-lang.org/stable/std/panic/struct.Location.html) where applicable).
+- **Mocking** — [`suitecase::mock`](https://docs.rs/suitecase/latest/suitecase/mock/index.html) provides [testify/mock](https://pkg.go.dev/github.com/stretchr/testify/mock)-style **expectations** and **call recording** ([`Mock`](https://docs.rs/suitecase/latest/suitecase/mock/struct.Mock.html), [`mock_args!`](https://docs.rs/suitecase/latest/suitecase/macro.mock_args.html)). Use [`suitecase::mock_args`](https://docs.rs/suitecase/latest/suitecase/macro.mock_args.html) at the crate root (same macro).
 
 ---
 
@@ -94,6 +96,45 @@ test_suite!(
 
 Run: `cargo test`. See the macro’s rustdoc for **ordering** (parallel harness) vs a single [`run`](https://docs.rs/suitecase/latest/suitecase/suite/fn.run.html) with [`RunConfig::all`](https://docs.rs/suitecase/latest/suitecase/suite/struct.RunConfig.html#method.all).
 
+### Assertions (`assert`)
+
+Import helpers from [`suitecase::assert`](https://docs.rs/suitecase/latest/suitecase/assert/index.html) inside `#[test]` functions, suite case bodies, or anywhere you want a **named** check that fails by **panicking** with a readable message.
+
+```rust
+use suitecase::assert::{assert_ok, contains_str, equal};
+
+let n = assert_ok(Ok::<_, &str>(42));
+equal(&n, &42);
+contains_str("hello world", "world");
+```
+
+See the module docs for the full flat list (collections, errors, floats, options/results, ordering, panics, pointers, time, …).
+
+### Mocking (`mock`)
+
+[`suitecase::mock`](https://docs.rs/suitecase/latest/suitecase/mock/index.html) is for **test doubles**: register expectations on a [`Mock`](https://docs.rs/suitecase/latest/suitecase/mock/struct.Mock.html), forward calls from your stub with [`method_called`](https://docs.rs/suitecase/latest/suitecase/mock/struct.Mock.html#method.method_called) and [`mock_args!`](https://docs.rs/suitecase/latest/suitecase/macro.mock_args.html), then verify with [`assert_expectations`](https://docs.rs/suitecase/latest/suitecase/mock/struct.Mock.html#method.assert_expectations) and a small [`TestingT`](https://docs.rs/suitecase/latest/suitecase/mock/trait.TestingT.html) implementation.
+
+```rust
+use suitecase::mock::{eq, Mock, TestingT};
+
+struct NoopT;
+impl TestingT for NoopT {
+    fn errorf(&self, _: &str) {}
+    fn fail_now(&self) {}
+}
+
+let m = Mock::new();
+m.on("greet", vec![eq("Ada".to_string())])
+    .returning(|| vec![Box::new("Hello, Ada".to_string())])
+    .finish();
+
+let out = m.method_called("greet", suitecase::mock_args!("Ada".to_string()));
+assert_eq!(out.string(0), "Hello, Ada");
+assert!(m.assert_expectations(&NoopT));
+```
+
+Unexpected calls **panic** from [`method_called`](https://docs.rs/suitecase/latest/suitecase/mock/struct.Mock.html#method.method_called) (see rustdoc). Matchers include [`eq`](https://docs.rs/suitecase/latest/suitecase/mock/fn.eq.html), [`anything`](https://docs.rs/suitecase/latest/suitecase/mock/fn.anything.html), [`anything_of_type`](https://docs.rs/suitecase/latest/suitecase/mock/fn.anything_of_type.html), [`matched_by`](https://docs.rs/suitecase/latest/suitecase/mock/fn.matched_by.html).
+
 ---
 
 ## Examples
@@ -101,6 +142,7 @@ Run: `cargo test`. See the macro’s rustdoc for **ordering** (parallel harness)
 | Example | Run |
 |--------|-----|
 | [`examples/quickstart.rs`](examples/quickstart.rs) | `cargo test --example quickstart` |
+| [`examples/mock.rs`](examples/mock.rs) | `cargo run --example mock` · `cargo test --example mock` (mocked HTTP-style JSON) |
 | [`examples/sqlx_sqlite.rs`](examples/sqlx_sqlite.rs) | `cargo test --example sqlx_sqlite` |
 | Every example at once | `cargo test --examples` |
 | Integration tests ([`tests/suite.rs`](tests/suite.rs)) | `cargo test` |
@@ -120,3 +162,5 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 - **`cargo doc --open`** — [`cases!`](https://docs.rs/suitecase/latest/suitecase/macro.cases.html) and [`test_suite!`](https://docs.rs/suitecase/latest/suitecase/macro.test_suite.html) include declaration / description / examples.
 - Crate root and [`suite`](https://docs.rs/suitecase/latest/suitecase/suite/index.html) describe how [`run`](https://docs.rs/suitecase/latest/suitecase/suite/fn.run.html) selects cases and orders hooks.
+- [`assert`](https://docs.rs/suitecase/latest/suitecase/assert/index.html) — panicking assertion helpers (submodules per domain; flat re-exports at the module root).
+- [`mock`](https://docs.rs/suitecase/latest/suitecase/mock/index.html) — `Mock`, matchers, [`Arguments`](https://docs.rs/suitecase/latest/suitecase/mock/struct.Arguments.html), [`mock_args!`](https://docs.rs/suitecase/latest/suitecase/macro.mock_args.html).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Heavy development:** The API is still evolving. Expect **breaking changes** between releases until a stable 1.0; pin an exact version (or git revision) in `Cargo.toml` if you need upgrades to be predictable.
 
-**Install · [Usage](#usage) · [Assertions](#assertions-assert) · [Mocking](#mocking-mock) · [Examples](#examples) · [Docs](https://docs.rs/suitecase)** (after publish; `cargo doc --open` locally)
+**Install · [Usage](#usage) · [Assertions](#assertions-assert) · [Mocking](#mocking-mock) · [Examples](#examples) · [AI-assisted changes](AI_USAGE.md) · [Docs](https://docs.rs/suitecase)** (after publish; `cargo doc --open` locally)
 
 ---
 
@@ -160,6 +160,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 ## More documentation
 
+- **[`AI_USAGE.md`](AI_USAGE.md)** — using LLMs to draft changes is allowed; you must understand the patch, justify it in review, and avoid unnecessary complexity (see file).
 - **`cargo doc --open`** — [`cases!`](https://docs.rs/suitecase/latest/suitecase/macro.cases.html) and [`test_suite!`](https://docs.rs/suitecase/latest/suitecase/macro.test_suite.html) include declaration / description / examples.
 - Crate root and [`suite`](https://docs.rs/suitecase/latest/suitecase/suite/index.html) describe how [`run`](https://docs.rs/suitecase/latest/suitecase/suite/fn.run.html) selects cases and orders hooks.
 - [`assert`](https://docs.rs/suitecase/latest/suitecase/assert/index.html) — panicking assertion helpers (submodules per domain; flat re-exports at the module root).

--- a/examples/mock.rs
+++ b/examples/mock.rs
@@ -1,0 +1,76 @@
+//! Mock HTTP **responses** with [`suitecase::mock`]: the code under test calls a small
+//! transport that records `GET` + path and returns a body string, as if it were an HTTP client.
+//!
+//! Run: `cargo run --example mock`  
+//! Test: `cargo test --example mock`
+
+use serde_json::Value;
+use suitecase::mock::{Mock, TestingT, eq};
+
+struct NoopT;
+
+impl TestingT for NoopT {
+    fn errorf(&self, _msg: &str) {}
+
+    fn fail_now(&self) {}
+}
+
+pub struct MockHttp {
+    pub mock: Mock,
+}
+
+impl MockHttp {
+    pub fn get(&self, path: &str) -> String {
+        let out = self
+            .mock
+            .method_called("GET", suitecase::mock_args!(path.to_string()));
+        out.string(0)
+    }
+}
+
+fn repo_stargazers_from_response(body: &str) -> u64 {
+    let v: Value = serde_json::from_str(body).expect("response JSON");
+    v["stargazers_count"].as_u64().expect("stargazers_count")
+}
+
+pub fn fetch_repo_stargazers(client: &MockHttp, owner: &str, repo: &str) -> u64 {
+    let path = format!("/repos/{owner}/{repo}");
+    let body = client.get(&path);
+    repo_stargazers_from_response(&body)
+}
+
+fn run_demo() {
+    let api = MockHttp { mock: Mock::new() };
+    let path = "/repos/octocat/Hello-World".to_string();
+    let response = r#"{"stargazers_count":5000,"name":"Hello-World"}"#;
+
+    api.mock
+        .on("GET", vec![eq(path.clone())])
+        .returning(move || vec![Box::new(response.to_string())])
+        .finish();
+
+    let stars = fetch_repo_stargazers(&api, "octocat", "Hello-World");
+    assert_eq!(stars, 5000);
+    assert!(api.mock.assert_expectations(&NoopT));
+}
+
+fn main() {
+    run_demo();
+    println!("mock HTTP example: ok");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demo_matches_main() {
+        run_demo();
+    }
+
+    #[test]
+    fn parses_github_style_json() {
+        let body = r#"{"stargazers_count":42}"#;
+        assert_eq!(repo_stargazers_from_response(body), 42);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 //! ```
 
 pub mod assert;
+pub mod mock;
 pub mod suite;
 
 pub use suite::{Case, HookFns, RunConfig, run};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,11 @@
 //! helpers (`equal`, `no_error`, `contains`, …) that **panic** on failure, for use in tests and
 //! suite case bodies.
 //!
+//! # Mocking
+//!
+//! The [`mod@mock`] module provides [testify/mock](https://pkg.go.dev/github.com/stretchr/testify/mock)-style
+//! expectations and call recording ([`mock::Mock`], [`mock::mock_args!`]).
+//!
 //! # Example
 //!
 //! ```

--- a/src/mock/arguments.rs
+++ b/src/mock/arguments.rs
@@ -1,0 +1,194 @@
+use std::any::Any;
+use std::fmt;
+
+use super::matchers::Matcher;
+
+pub struct Arguments {
+    values: Vec<Box<dyn Any + Send>>,
+}
+
+impl Arguments {
+    pub fn from_boxes(values: Vec<Box<dyn Any + Send>>) -> Self {
+        Self { values }
+    }
+
+    pub fn into_boxes(self) -> Vec<Box<dyn Any + Send>> {
+        self.values
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn as_raw(&self) -> &[Box<dyn Any + Send>] {
+        &self.values
+    }
+
+    pub fn get<T: 'static>(&self, index: usize) -> Option<&T> {
+        self.values.get(index).and_then(|b| b.downcast_ref())
+    }
+
+    pub fn get_box(&self, index: usize) -> Option<&(dyn Any + Send)> {
+        self.values.get(index).map(|b| b.as_ref())
+    }
+
+    pub fn int(&self, index: usize) -> i64 {
+        self.values
+            .get(index)
+            .and_then(|b| {
+                if let Some(v) = b.downcast_ref::<i64>() {
+                    Some(*v)
+                } else if let Some(v) = b.downcast_ref::<i32>() {
+                    Some(*v as i64)
+                } else if let Some(v) = b.downcast_ref::<isize>() {
+                    Some(*v as i64)
+                } else if let Some(v) = b.downcast_ref::<u32>() {
+                    Some(*v as i64)
+                } else if let Some(v) = b.downcast_ref::<u64>() {
+                    Some(*v as i64)
+                } else {
+                    None
+                }
+            })
+            .expect("argument is not an integer")
+    }
+
+    pub fn bool(&self, index: usize) -> bool {
+        *self
+            .values
+            .get(index)
+            .and_then(|b| b.downcast_ref::<bool>())
+            .expect("argument is not bool")
+    }
+
+    pub fn string(&self, index: usize) -> String {
+        if let Some(s) = self.get::<String>(index) {
+            return s.clone();
+        }
+        self.get::<&'static str>(index)
+            .map(|s| (*s).to_string())
+            .expect("argument is not a string")
+    }
+
+    pub fn error_display(&self, index: usize) -> String {
+        let b = self.values.get(index).expect("missing argument");
+        if let Some(e) = b.downcast_ref::<String>() {
+            return e.clone();
+        }
+        if let Some(e) = b.downcast_ref::<&'static str>() {
+            return (*e).to_string();
+        }
+        format!("{}", MockErrorDebug(b.as_ref()))
+    }
+
+    pub fn assert_matches(&self, testing: &dyn TestingT, expected: &[Box<dyn Matcher>]) -> bool {
+        if self.values.len() != expected.len() {
+            testing.errorf(&format!(
+                "argument count mismatch: got {} want {}",
+                self.values.len(),
+                expected.len()
+            ));
+            testing.fail_now();
+            return false;
+        }
+        for (i, (arg, m)) in self.values.iter().zip(expected.iter()).enumerate() {
+            if !m.matches(arg.as_ref()) {
+                testing.errorf(&format!("argument {i} did not match"));
+                testing.fail_now();
+                return false;
+            }
+        }
+        true
+    }
+}
+
+struct MockErrorDebug<'a>(&'a dyn Any);
+
+impl fmt::Display for MockErrorDebug<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(e) = self.0.downcast_ref::<String>() {
+            return write!(f, "{e}");
+        }
+        if let Some(e) = self.0.downcast_ref::<&'static str>() {
+            return write!(f, "{e}");
+        }
+        write!(f, "{:?}", self.0.type_id())
+    }
+}
+
+pub trait TestingT {
+    fn errorf(&self, msg: &str);
+    fn fail_now(&self);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::super::eq;
+    use super::*;
+
+    struct RecordingT {
+        messages: Mutex<Vec<String>>,
+        fail_now_hits: AtomicUsize,
+    }
+
+    impl RecordingT {
+        fn new() -> Self {
+            Self {
+                messages: Mutex::new(Vec::new()),
+                fail_now_hits: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl TestingT for RecordingT {
+        fn errorf(&self, msg: &str) {
+            self.messages.lock().unwrap().push(msg.to_string());
+        }
+
+        fn fail_now(&self) {
+            self.fail_now_hits.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn int_coercion() {
+        let a = Arguments::from_boxes(vec![Box::new(42i32)]);
+        assert_eq!(a.int(0), 42);
+    }
+
+    #[test]
+    fn assert_matches_succeeds_when_matchers_align() {
+        let a = Arguments::from_boxes(vec![Box::new(1i32), Box::new("z".to_string())]);
+        let t = RecordingT::new();
+        assert!(a.assert_matches(&t, &[eq(1i32), eq("z".to_string())]));
+        assert_eq!(t.fail_now_hits.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn assert_matches_fails_on_len_mismatch() {
+        let a = Arguments::from_boxes(vec![Box::new(1i32)]);
+        let t = RecordingT::new();
+        assert!(!a.assert_matches(&t, &[eq(1i32), eq(2i32)]));
+        assert_eq!(t.fail_now_hits.load(Ordering::SeqCst), 1);
+        assert!(
+            t.messages.lock().unwrap()[0].contains("argument count mismatch"),
+            "{:?}",
+            t.messages.lock().unwrap()
+        );
+    }
+
+    #[test]
+    fn assert_matches_fails_on_predicate() {
+        let a = Arguments::from_boxes(vec![Box::new(9i32)]);
+        let t = RecordingT::new();
+        assert!(!a.assert_matches(&t, &[eq(1i32)]));
+        assert_eq!(t.fail_now_hits.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/mock/arguments.rs
+++ b/src/mock/arguments.rs
@@ -1,41 +1,68 @@
+//! Typed access to values recorded or returned through [`Mock::method_called`](crate::mock::Mock::method_called).
+//!
+//! Values are stored as [`Box<dyn Any + Send>`](std::any::Any); use [`Arguments::get`] or the
+//! helpers [`Arguments::int`], [`Arguments::bool`], [`Arguments::string`], etc.
+
 use std::any::Any;
 use std::fmt;
 
 use super::matchers::Matcher;
 
+/// A list of boxed arguments or return values for a single mock call.
+///
+/// # Examples
+///
+/// ```
+/// use suitecase::mock::Arguments;
+///
+/// let a = Arguments::from_boxes(vec![Box::new(40i32), Box::new(2i32)]);
+/// assert_eq!(a.int(0) + a.int(1), 42);
+/// ```
 pub struct Arguments {
     values: Vec<Box<dyn Any + Send>>,
 }
 
 impl Arguments {
+    /// Wraps a vector of boxed values (one per positional argument or return slot).
     pub fn from_boxes(values: Vec<Box<dyn Any + Send>>) -> Self {
         Self { values }
     }
 
+    /// Consumes `self` and returns the underlying boxes.
     pub fn into_boxes(self) -> Vec<Box<dyn Any + Send>> {
         self.values
     }
 
+    /// Number of slots.
     pub fn len(&self) -> usize {
         self.values.len()
     }
 
+    /// `true` when there are no slots.
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
 
+    /// Raw slice of argument boxes.
     pub fn as_raw(&self) -> &[Box<dyn Any + Send>] {
         &self.values
     }
 
+    /// Returns a reference to slot `index` if its type matches `T`.
     pub fn get<T: 'static>(&self, index: usize) -> Option<&T> {
         self.values.get(index).and_then(|b| b.downcast_ref())
     }
 
+    /// Like [`get`](Self::get) but returns the trait object for custom downcasting.
     pub fn get_box(&self, index: usize) -> Option<&(dyn Any + Send)> {
         self.values.get(index).map(|b| b.as_ref())
     }
 
+    /// Reads an integer slot, accepting several fixed-width integer types.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slot is missing or not an integer type supported by this helper.
     pub fn int(&self, index: usize) -> i64 {
         self.values
             .get(index)
@@ -55,6 +82,11 @@ impl Arguments {
             .expect("argument is not an integer")
     }
 
+    /// Reads a `bool` slot.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slot is missing or not a `bool`.
     pub fn bool(&self, index: usize) -> bool {
         *self
             .values
@@ -63,6 +95,11 @@ impl Arguments {
             .expect("argument is not bool")
     }
 
+    /// Reads a [`String`] or `&'static str` slot.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slot is missing or not string-like as above.
     pub fn string(&self, index: usize) -> String {
         if let Some(s) = self.get::<String>(index) {
             return s.clone();
@@ -72,6 +109,11 @@ impl Arguments {
             .expect("argument is not a string")
     }
 
+    /// Best-effort string for error-like values (`String`, `&str`, otherwise [`TypeId`](std::any::TypeId) debug).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of range.
     pub fn error_display(&self, index: usize) -> String {
         let b = self.values.get(index).expect("missing argument");
         if let Some(e) = b.downcast_ref::<String>() {
@@ -83,6 +125,24 @@ impl Arguments {
         format!("{}", MockErrorDebug(b.as_ref()))
     }
 
+    /// Compares this argument list against `expected` matchers, notifying `testing` on failure.
+    ///
+    /// Returns `false` after the first failed check.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use suitecase::mock::{eq, Arguments, TestingT};
+    ///
+    /// struct T;
+    /// impl TestingT for T {
+    ///     fn errorf(&self, _: &str) {}
+    ///     fn fail_now(&self) {}
+    /// }
+    ///
+    /// let a = Arguments::from_boxes(vec![Box::new(7i32)]);
+    /// assert!(a.assert_matches(&T, &[eq(7i32)]));
+    /// ```
     pub fn assert_matches(&self, testing: &dyn TestingT, expected: &[Box<dyn Matcher>]) -> bool {
         if self.values.len() != expected.len() {
             testing.errorf(&format!(
@@ -118,8 +178,27 @@ impl fmt::Display for MockErrorDebug<'_> {
     }
 }
 
+/// Hooks for reporting assertion failures from mock verification (similar to Go’s `testing.T`).
+///
+/// Implement this for your test context: typically [`errorf`](TestingT::errorf) records a message
+/// and [`fail_now`](TestingT::fail_now) marks the test as failed or aborts the current check.
+///
+/// # Examples
+///
+/// ```
+/// use suitecase::mock::TestingT;
+///
+/// struct Counting;
+///
+/// impl TestingT for Counting {
+///     fn errorf(&self, _: &str) {}
+///     fn fail_now(&self) {}
+/// }
+/// ```
 pub trait TestingT {
+    /// Records a failure message (e.g. log or buffer).
     fn errorf(&self, msg: &str);
+    /// Marks the current test or assertion as failed (for example by panicking or setting a flag).
     fn fail_now(&self);
 }
 

--- a/src/mock/arguments.rs
+++ b/src/mock/arguments.rs
@@ -48,10 +48,8 @@ impl Arguments {
                     Some(*v as i64)
                 } else if let Some(v) = b.downcast_ref::<u32>() {
                     Some(*v as i64)
-                } else if let Some(v) = b.downcast_ref::<u64>() {
-                    Some(*v as i64)
                 } else {
-                    None
+                    b.downcast_ref::<u64>().map(|v| *v as i64)
                 }
             })
             .expect("argument is not an integer")

--- a/src/mock/matchers.rs
+++ b/src/mock/matchers.rs
@@ -1,9 +1,18 @@
+//! Argument [matchers](Matcher) used with [`Mock::on`](crate::Mock::on) and
+//! [`Arguments::assert_matches`](crate::Arguments::assert_matches).
+//!
+//! Prefer the helpers [`anything`], [`anything_of_type`], [`eq`], and [`matched_by`].
+
 use std::any::{Any, TypeId};
 
+/// Predicate used to compare one boxed argument against an expectation.
+///
 pub trait Matcher: Send {
+    /// Returns `true` when this matcher accepts `arg`.
     fn matches(&self, arg: &dyn Any) -> bool;
 }
 
+/// Matches any value.
 pub struct Anything;
 
 impl Matcher for Anything {
@@ -12,14 +21,41 @@ impl Matcher for Anything {
     }
 }
 
+/// Wildcard matcher: always matches.
+///
+/// # Examples
+///
+/// ```
+/// use suitecase::mock::{anything, Mock};
+///
+/// let m = Mock::new();
+/// m.on("x", vec![anything()])
+///     .returning(|| vec![Box::new(0u8)])
+///     .finish();
+/// m.method_called("x", suitecase::mock_args!("anything goes"));
+/// ```
 pub fn anything() -> Box<dyn Matcher> {
     Box::new(Anything)
 }
 
+/// Matches when the dynamic type equals `T` ([`TypeId`](std::any::TypeId)).
 pub struct OfType {
     id: TypeId,
 }
 
+/// Matches any value whose concrete type is `T`.
+///
+/// # Examples
+///
+/// ```
+/// use suitecase::mock::{anything_of_type, Mock};
+///
+/// let m = Mock::new();
+/// m.on("x", vec![anything_of_type::<i32>()])
+///     .returning(|| vec![Box::new(())])
+///     .finish();
+/// m.method_called("x", suitecase::mock_args!(42i32));
+/// ```
 pub fn anything_of_type<T: 'static>() -> Box<dyn Matcher> {
     Box::new(OfType {
         id: TypeId::of::<T>(),
@@ -32,6 +68,7 @@ impl Matcher for OfType {
     }
 }
 
+/// Equality matcher for a concrete `T` ([`PartialEq`]).
 pub struct EqMatcher<T: PartialEq + Send + 'static>(pub T);
 
 impl<T: PartialEq + Send + 'static> Matcher for EqMatcher<T> {
@@ -42,10 +79,25 @@ impl<T: PartialEq + Send + 'static> Matcher for EqMatcher<T> {
     }
 }
 
+/// Matches when the argument downcasts to `T` and compares equal to `v`.
+///
+/// # Examples
+///
+/// ```
+/// use suitecase::mock::{eq, Mock};
+///
+/// let m = Mock::new();
+/// m.on("id", vec![eq(99u32)])
+///     .returning(|| vec![Box::new("ok".to_string())])
+///     .finish();
+/// let out = m.method_called("id", suitecase::mock_args!(99u32));
+/// assert_eq!(out.string(0), "ok");
+/// ```
 pub fn eq<T: PartialEq + Send + 'static>(v: T) -> Box<dyn Matcher> {
     Box::new(EqMatcher(v))
 }
 
+/// Matcher wrapping a custom predicate over [`Any`].
 pub struct MatchedBy<F>
 where
     F: Fn(&dyn Any) -> bool + Send,
@@ -62,6 +114,20 @@ where
     }
 }
 
+/// Custom match: `f` receives the erased argument and returns whether it matches.
+///
+/// # Examples
+///
+/// ```
+/// use suitecase::mock::{matched_by, Mock};
+///
+/// let m = Mock::new();
+/// m.on("x", vec![matched_by(|a| a.downcast_ref::<i32>().map(|v| *v > 0).unwrap_or(false))])
+///     .returning(|| vec![Box::new(1i32)])
+///     .finish();
+/// let out = m.method_called("x", suitecase::mock_args!(7i32));
+/// assert_eq!(out.int(0), 1i64);
+/// ```
 pub fn matched_by<F>(f: F) -> Box<dyn Matcher>
 where
     F: Fn(&dyn Any) -> bool + Send + 'static,

--- a/src/mock/matchers.rs
+++ b/src/mock/matchers.rs
@@ -1,0 +1,70 @@
+use std::any::{Any, TypeId};
+
+pub trait Matcher: Send {
+    fn matches(&self, arg: &dyn Any) -> bool;
+}
+
+pub struct Anything;
+
+impl Matcher for Anything {
+    fn matches(&self, _arg: &dyn Any) -> bool {
+        true
+    }
+}
+
+pub fn anything() -> Box<dyn Matcher> {
+    Box::new(Anything)
+}
+
+pub struct OfType {
+    id: TypeId,
+}
+
+pub fn anything_of_type<T: 'static>() -> Box<dyn Matcher> {
+    Box::new(OfType {
+        id: TypeId::of::<T>(),
+    })
+}
+
+impl Matcher for OfType {
+    fn matches(&self, arg: &dyn Any) -> bool {
+        arg.type_id() == self.id
+    }
+}
+
+pub struct EqMatcher<T: PartialEq + Send + 'static>(pub T);
+
+impl<T: PartialEq + Send + 'static> Matcher for EqMatcher<T> {
+    fn matches(&self, arg: &dyn Any) -> bool {
+        arg.downcast_ref::<T>()
+            .map(|v| *v == self.0)
+            .unwrap_or(false)
+    }
+}
+
+pub fn eq<T: PartialEq + Send + 'static>(v: T) -> Box<dyn Matcher> {
+    Box::new(EqMatcher(v))
+}
+
+pub struct MatchedBy<F>
+where
+    F: Fn(&dyn Any) -> bool + Send,
+{
+    pub f: F,
+}
+
+impl<F> Matcher for MatchedBy<F>
+where
+    F: Fn(&dyn Any) -> bool + Send,
+{
+    fn matches(&self, arg: &dyn Any) -> bool {
+        (self.f)(arg)
+    }
+}
+
+pub fn matched_by<F>(f: F) -> Box<dyn Matcher>
+where
+    F: Fn(&dyn Any) -> bool + Send + 'static,
+{
+    Box::new(MatchedBy { f })
+}

--- a/src/mock/mock_test.rs
+++ b/src/mock/mock_test.rs
@@ -1,0 +1,294 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use super::{
+    Mock, TestingT, anything, anything_of_type, assert_expectations_for_objects, eq, matched_by,
+};
+
+struct NoopT;
+impl TestingT for NoopT {
+    fn errorf(&self, _msg: &str) {}
+    fn fail_now(&self) {}
+}
+
+struct RecordingT {
+    messages: Mutex<Vec<String>>,
+    fail_now_hits: AtomicUsize,
+}
+
+impl RecordingT {
+    fn new() -> Self {
+        Self {
+            messages: Mutex::new(Vec::new()),
+            fail_now_hits: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl TestingT for RecordingT {
+    fn errorf(&self, msg: &str) {
+        self.messages.lock().unwrap().push(msg.to_string());
+    }
+
+    fn fail_now(&self) {
+        self.fail_now_hits.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn expectation_met_finish() {
+    let m = Mock::new();
+    m.on("do_it", vec![eq(1i32)])
+        .returning(|| vec![Box::new(true), Box::new(false)])
+        .finish();
+    let out = m.method_called("do_it", crate::mock_args!(1i32));
+    assert!(out.bool(0));
+    assert!(!out.bool(1));
+    assert!(m.assert_expectations(&NoopT));
+}
+
+#[test]
+fn assert_expectations_fails_when_required_never_invoked() {
+    let m = Mock::new();
+    m.on("idle", vec![])
+        .returning(|| vec![Box::new(0u8)])
+        .finish();
+    let t = RecordingT::new();
+    assert!(!m.assert_expectations(&t));
+    assert_eq!(t.fail_now_hits.load(Ordering::SeqCst), 1);
+    let msgs = t.messages.lock().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert!(
+        msgs[0].contains("idle"),
+        "msg should mention method: {:?}",
+        msgs[0]
+    );
+    assert!(msgs[0].contains("0 invocations"), "{:?}", msgs[0]);
+}
+
+#[test]
+fn assert_expectations_passes_for_maybe_without_call() {
+    let m = Mock::new();
+    m.on("opt", vec![]).returning(|| vec![Box::new(())]).maybe();
+    assert!(m.assert_expectations(&NoopT));
+}
+
+#[test]
+fn assert_expectations_ignores_removed_expectation() {
+    let m = Mock::new();
+    let h = m
+        .on("gone", vec![])
+        .returning(|| vec![Box::new(0u8)])
+        .finish();
+    h.unset();
+    assert!(m.assert_expectations(&NoopT));
+}
+
+#[test]
+fn anything_matcher() {
+    let m = Mock::new();
+    m.on("x", vec![anything()])
+        .returning(|| vec![Box::new(())])
+        .once();
+    m.method_called("x", crate::mock_args!("hello"));
+    assert!(m.assert_expectations(&NoopT));
+}
+
+#[test]
+fn assert_expectations_for_objects_ok() {
+    let a = Mock::new();
+    let b = Mock::new();
+    a.on("a", vec![])
+        .returning(|| vec![Box::new(0i32)])
+        .finish();
+    b.on("b", vec![])
+        .returning(|| vec![Box::new(0i32)])
+        .finish();
+    a.method_called("a", crate::mock_args!());
+    b.method_called("b", crate::mock_args!());
+    assert!(assert_expectations_for_objects(&NoopT, &[&a, &b]));
+}
+
+#[test]
+fn assert_expectations_for_objects_fails_on_first_mock() {
+    let a = Mock::new();
+    let b = Mock::new();
+    a.on("a", vec![])
+        .returning(|| vec![Box::new(0i32)])
+        .finish();
+    b.on("b", vec![])
+        .returning(|| vec![Box::new(0i32)])
+        .finish();
+    a.method_called("a", crate::mock_args!());
+    let t = RecordingT::new();
+    assert!(!assert_expectations_for_objects(&t, &[&a, &b]));
+    assert_eq!(t.fail_now_hits.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+#[should_panic(expected = "unexpected call")]
+fn unexpected_call_panics() {
+    let m = Mock::new();
+    m.method_called("nope", crate::mock_args!());
+}
+
+#[test]
+#[should_panic(expected = "unexpected call")]
+fn once_exhausted_then_second_call_panics() {
+    let m = Mock::new();
+    m.on("one", vec![eq(0i32)])
+        .returning(|| vec![Box::new(())])
+        .once();
+    m.method_called("one", crate::mock_args!(0i32));
+    m.method_called("one", crate::mock_args!(0i32));
+}
+
+#[test]
+fn times_requires_exact_invocation_count() {
+    let m = Mock::new();
+    m.on("n", vec![]).returning(|| vec![Box::new(0u8)]).times(2);
+    m.method_called("n", crate::mock_args!());
+    assert!(!m.assert_expectations(&RecordingT::new()));
+    m.method_called("n", crate::mock_args!());
+    assert!(m.assert_expectations(&NoopT));
+}
+
+#[test]
+fn twice_matches_two_calls() {
+    let m = Mock::new();
+    m.on("t", vec![]).returning(|| vec![Box::new(())]).twice();
+    m.method_called("t", crate::mock_args!());
+    assert!(!m.assert_expectations(&RecordingT::new()));
+    m.method_called("t", crate::mock_args!());
+    assert!(m.assert_expectations(&NoopT));
+}
+
+#[test]
+fn assert_called_finds_matching_record() {
+    let m = Mock::new();
+    m.on("f", vec![eq(7i32)])
+        .returning(|| vec![Box::new(())])
+        .finish();
+    m.method_called("f", crate::mock_args!(7i32));
+    assert!(m.assert_called(&NoopT, "f", &[eq(7i32)]));
+}
+
+#[test]
+fn assert_called_fails_without_match() {
+    let m = Mock::new();
+    m.on("f", vec![eq(1i32)])
+        .returning(|| vec![Box::new(())])
+        .finish();
+    m.method_called("f", crate::mock_args!(1i32));
+    let t = RecordingT::new();
+    assert!(!m.assert_called(&t, "f", &[eq(2i32)]));
+    assert_eq!(t.fail_now_hits.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn assert_not_called_passes_when_no_match() {
+    let m = Mock::new();
+    m.on("f", vec![anything()])
+        .returning(|| vec![Box::new(())])
+        .finish();
+    m.method_called("f", crate::mock_args!(2i32));
+    assert!(m.assert_not_called(&NoopT, "f", &[eq(1i32)]));
+}
+
+#[test]
+fn assert_not_called_fails_when_match_exists() {
+    let m = Mock::new();
+    m.on("f", vec![eq(1i32)])
+        .returning(|| vec![Box::new(())])
+        .finish();
+    m.method_called("f", crate::mock_args!(1i32));
+    let t = RecordingT::new();
+    assert!(!m.assert_not_called(&t, "f", &[eq(1i32)]));
+    assert_eq!(t.fail_now_hits.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn assert_number_of_calls_counts_by_method_name() {
+    let m = Mock::new();
+    m.on("g", vec![]).returning(|| vec![Box::new(())]).finish();
+    m.on("g", vec![]).returning(|| vec![Box::new(())]).finish();
+    m.method_called("g", crate::mock_args!());
+    m.method_called("g", crate::mock_args!());
+    assert!(m.assert_number_of_calls(&NoopT, "g", 2));
+}
+
+#[test]
+fn assert_number_of_calls_fails_on_wrong_count() {
+    let m = Mock::new();
+    m.on("g", vec![]).returning(|| vec![Box::new(())]).finish();
+    m.method_called("g", crate::mock_args!());
+    let t = RecordingT::new();
+    assert!(!m.assert_number_of_calls(&t, "g", 2));
+    assert_eq!(t.fail_now_hits.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn run_hook_runs_before_return() {
+    let m = Mock::new();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_run = hits.clone();
+    m.on("r", vec![eq(5i32)])
+        .returning(|| vec![Box::new(99i32)])
+        .run(move |args| {
+            assert_eq!(args.int(0), 5);
+            hits_run.fetch_add(1, Ordering::SeqCst);
+        })
+        .once();
+    let out = m.method_called("r", crate::mock_args!(5i32));
+    assert_eq!(out.int(0), 99);
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn anything_of_type_matches_concrete_type() {
+    let m = Mock::new();
+    m.on("t", vec![anything_of_type::<i32>()])
+        .returning(|| vec![Box::new(())])
+        .once();
+    m.method_called("t", crate::mock_args!(42i32));
+    assert!(m.assert_expectations(&NoopT));
+}
+
+#[test]
+fn matched_by_custom_predicate() {
+    let m = Mock::new();
+    m.on(
+        "t",
+        vec![matched_by(|a| a.downcast_ref::<i32>() == Some(&3))],
+    )
+    .returning(|| vec![Box::new(())])
+    .once();
+    m.method_called("t", crate::mock_args!(3i32));
+    assert!(m.assert_expectations(&NoopT));
+}
+
+#[test]
+#[should_panic(expected = "boom")]
+fn panic_expectation_panics_in_method_called() {
+    let m = Mock::new();
+    m.on("p", vec![])
+        .returning(|| vec![Box::new(())])
+        .panic("boom");
+    m.method_called("p", crate::mock_args!());
+}
+
+#[test]
+fn unset_allows_re_registering_same_method() {
+    let m = Mock::new();
+    let h = m
+        .on("m", vec![eq(1i32)])
+        .returning(|| vec![Box::new(10i32)])
+        .finish();
+    h.unset();
+    m.on("m", vec![eq(2i32)])
+        .returning(|| vec![Box::new(20i32)])
+        .finish();
+    let out = m.method_called("m", crate::mock_args!(2i32));
+    assert_eq!(out.int(0), 20);
+    assert!(m.assert_expectations(&NoopT));
+}

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 use arguments::Arguments as Args;
 use matchers::Matcher;
 
+type RunHook = Box<dyn Fn(&Args) + Send + 'static>;
+
 pub struct Mock {
     inner: Mutex<MockInner>,
 }
@@ -34,7 +36,7 @@ struct Expectation {
     remaining: Option<u32>,
     maybe: bool,
     removed: bool,
-    run: Option<Box<dyn Fn(&Args) + Send + 'static>>,
+    run: Option<RunHook>,
     delay: Option<Duration>,
     panic_msg: Option<String>,
     invocations: u32,
@@ -59,7 +61,7 @@ where
     method: &'static str,
     matchers: Vec<Box<dyn Matcher>>,
     f: F,
-    run: Option<Box<dyn Fn(&Args) + Send + 'static>>,
+    run: Option<RunHook>,
     delay: Option<Duration>,
     panic_msg: Option<String>,
     maybe: bool,
@@ -186,6 +188,12 @@ impl ActiveExpectation<'_> {
     }
 }
 
+impl Default for Mock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Mock {
     pub fn new() -> Self {
         Self {
@@ -217,7 +225,7 @@ impl Mock {
                 if exp.removed || exp.method != method {
                     continue;
                 }
-                let can = exp.remaining.map_or(true, |n| n > 0);
+                let can = exp.remaining.is_none_or(|n| n > 0);
                 let ok = can && args_match(&exp.matchers, args.as_raw());
                 if ok {
                     matched_idx = Some(i);
@@ -245,9 +253,7 @@ impl Mock {
                 }
                 let sleep = exp.delay;
                 let panic_m = exp.panic_msg.clone();
-                let ret_fn = match &exp.return_gen {
-                    ReturnGen::Fn(f) => f,
-                };
+                let ReturnGen::Fn(ret_fn) = &exp.return_gen;
                 let out = ret_fn();
                 (sleep, panic_m, out)
             };

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -47,7 +47,7 @@ mod arguments;
 mod matchers;
 
 pub use arguments::{Arguments, TestingT};
-pub use matchers::{anything, anything_of_type, eq, matched_by, Matcher};
+pub use matchers::{Matcher, anything, anything_of_type, eq, matched_by};
 
 use std::any::Any;
 use std::sync::Mutex;

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -1,0 +1,384 @@
+mod arguments;
+mod matchers;
+
+pub use arguments::{Arguments, TestingT};
+pub use matchers::{anything, anything_of_type, eq, matched_by};
+
+use std::any::Any;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use arguments::Arguments as Args;
+use matchers::Matcher;
+
+pub struct Mock {
+    inner: Mutex<MockInner>,
+}
+
+struct MockInner {
+    expectations: Vec<Expectation>,
+    calls: Vec<RecordedCall>,
+    next_id: usize,
+}
+
+struct RecordedCall {
+    method: &'static str,
+    args: Vec<Box<dyn Any + Send>>,
+}
+
+struct Expectation {
+    id: usize,
+    method: &'static str,
+    matchers: Vec<Box<dyn Matcher>>,
+    return_gen: ReturnGen,
+    remaining: Option<u32>,
+    maybe: bool,
+    removed: bool,
+    run: Option<Box<dyn Fn(&Args) + Send + 'static>>,
+    delay: Option<Duration>,
+    panic_msg: Option<String>,
+    invocations: u32,
+    assert_exact: Option<u32>,
+}
+
+enum ReturnGen {
+    Fn(Box<dyn Fn() -> Vec<Box<dyn Any + Send>> + Send + 'static>),
+}
+
+pub struct CallBuilder<'a> {
+    mock: &'a Mock,
+    method: &'static str,
+    matchers: Vec<Box<dyn Matcher>>,
+}
+
+pub struct PostReturn<'a, F>
+where
+    F: Fn() -> Vec<Box<dyn Any + Send>> + Send + 'static,
+{
+    mock: &'a Mock,
+    method: &'static str,
+    matchers: Vec<Box<dyn Matcher>>,
+    f: F,
+    run: Option<Box<dyn Fn(&Args) + Send + 'static>>,
+    delay: Option<Duration>,
+    panic_msg: Option<String>,
+    maybe: bool,
+    remaining: Option<u32>,
+    assert_exact: Option<u32>,
+}
+
+pub struct ActiveExpectation<'a> {
+    mock: &'a Mock,
+    id: usize,
+}
+
+impl<'a> CallBuilder<'a> {
+    pub fn returning<F>(self, f: F) -> PostReturn<'a, F>
+    where
+        F: Fn() -> Vec<Box<dyn Any + Send>> + Send + 'static,
+    {
+        PostReturn {
+            mock: self.mock,
+            method: self.method,
+            matchers: self.matchers,
+            f,
+            run: None,
+            delay: None,
+            panic_msg: None,
+            maybe: false,
+            remaining: None,
+            assert_exact: None,
+        }
+    }
+}
+
+impl<'a, F> PostReturn<'a, F>
+where
+    F: Fn() -> Vec<Box<dyn Any + Send>> + Send + 'static,
+{
+    pub fn run<R: Fn(&Args) + Send + 'static>(mut self, r: R) -> Self {
+        self.run = Some(Box::new(r));
+        self
+    }
+
+    pub fn after(mut self, d: Duration) -> Self {
+        self.delay = Some(d);
+        self
+    }
+
+    pub fn maybe(mut self) -> ActiveExpectation<'a> {
+        self.maybe = true;
+        self.remaining = None;
+        self.assert_exact = None;
+        self.commit()
+    }
+
+    pub fn once(mut self) -> ActiveExpectation<'a> {
+        self.remaining = Some(1);
+        self.assert_exact = Some(1);
+        self.commit()
+    }
+
+    pub fn twice(mut self) -> ActiveExpectation<'a> {
+        self.remaining = Some(2);
+        self.assert_exact = Some(2);
+        self.commit()
+    }
+
+    pub fn times(mut self, n: u32) -> ActiveExpectation<'a> {
+        self.remaining = Some(n);
+        self.assert_exact = Some(n);
+        self.commit()
+    }
+
+    pub fn unlimited(mut self) -> ActiveExpectation<'a> {
+        self.remaining = None;
+        self.assert_exact = None;
+        self.commit()
+    }
+
+    pub fn finish(self) -> ActiveExpectation<'a> {
+        self.unlimited()
+    }
+
+    pub fn panic(mut self, msg: impl Into<String>) -> ActiveExpectation<'a> {
+        self.panic_msg = Some(msg.into());
+        self.remaining = Some(1);
+        self.assert_exact = Some(1);
+        self.commit()
+    }
+
+    fn commit(self) -> ActiveExpectation<'a> {
+        let mut inner = self.mock.inner.lock().unwrap();
+        let id = inner.next_id;
+        inner.next_id += 1;
+        let f = self.f;
+        inner.expectations.push(Expectation {
+            id,
+            method: self.method,
+            matchers: self.matchers,
+            return_gen: ReturnGen::Fn(Box::new(f)),
+            remaining: self.remaining,
+            maybe: self.maybe,
+            removed: false,
+            run: self.run,
+            delay: self.delay,
+            panic_msg: self.panic_msg,
+            invocations: 0,
+            assert_exact: self.assert_exact,
+        });
+        ActiveExpectation {
+            mock: self.mock,
+            id,
+        }
+    }
+}
+
+impl ActiveExpectation<'_> {
+    pub fn unset(self) {
+        let mut inner = self.mock.inner.lock().unwrap();
+        for e in &mut inner.expectations {
+            if e.id == self.id {
+                e.removed = true;
+                break;
+            }
+        }
+    }
+}
+
+impl Mock {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(MockInner {
+                expectations: Vec::new(),
+                calls: Vec::new(),
+                next_id: 0,
+            }),
+        }
+    }
+
+    pub fn on<'a>(
+        &'a self,
+        method: &'static str,
+        matchers: Vec<Box<dyn Matcher>>,
+    ) -> CallBuilder<'a> {
+        CallBuilder {
+            mock: self,
+            method,
+            matchers,
+        }
+    }
+
+    pub fn method_called(&self, method: &'static str, args: Args) -> Args {
+        let (sleep, panic_m, out) = {
+            let mut inner = self.inner.lock().unwrap();
+            let mut matched_idx = None;
+            for (i, exp) in inner.expectations.iter().enumerate() {
+                if exp.removed || exp.method != method {
+                    continue;
+                }
+                let can = exp.remaining.map_or(true, |n| n > 0);
+                let ok = can && args_match(&exp.matchers, args.as_raw());
+                if ok {
+                    matched_idx = Some(i);
+                    break;
+                }
+            }
+            let Some(i) = matched_idx else {
+                drop(inner);
+                panic!("unexpected call to {method}");
+            };
+            let (sleep, panic_m, out) = {
+                let exp = &mut inner.expectations[i];
+                if let Some(r) = &exp.run {
+                    r(&args);
+                }
+                exp.invocations += 1;
+                match exp.remaining {
+                    None => {}
+                    Some(1) => {
+                        exp.remaining = Some(0);
+                    }
+                    Some(n) => {
+                        exp.remaining = Some(n - 1);
+                    }
+                }
+                let sleep = exp.delay;
+                let panic_m = exp.panic_msg.clone();
+                let ret_fn = match &exp.return_gen {
+                    ReturnGen::Fn(f) => f,
+                };
+                let out = ret_fn();
+                (sleep, panic_m, out)
+            };
+            let boxes = args.into_boxes();
+            inner.calls.push(RecordedCall {
+                method,
+                args: boxes,
+            });
+            (sleep, panic_m, out)
+        };
+        if let Some(d) = sleep {
+            std::thread::sleep(d);
+        }
+        if let Some(msg) = panic_m {
+            panic!("{msg}");
+        }
+        Args::from_boxes(out)
+    }
+
+    pub fn assert_expectations(&self, t: &dyn TestingT) -> bool {
+        let inner = self.inner.lock().unwrap();
+        for exp in &inner.expectations {
+            if exp.removed || exp.maybe {
+                continue;
+            }
+            let ok = match exp.assert_exact {
+                None => exp.invocations >= 1,
+                Some(n) => exp.invocations == n,
+            };
+            if !ok {
+                t.errorf(&format!(
+                    "expectation for {} not met: got {} invocations",
+                    exp.method, exp.invocations
+                ));
+                t.fail_now();
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn assert_called(
+        &self,
+        t: &dyn TestingT,
+        method: &'static str,
+        matchers: &[Box<dyn Matcher>],
+    ) -> bool {
+        let inner = self.inner.lock().unwrap();
+        for rec in &inner.calls {
+            if rec.method != method {
+                continue;
+            }
+            if args_match(matchers, &rec.args) {
+                return true;
+            }
+        }
+        t.errorf(&format!(
+            "expected {method} to have been called with matching arguments"
+        ));
+        t.fail_now();
+        false
+    }
+
+    pub fn assert_not_called(
+        &self,
+        t: &dyn TestingT,
+        method: &'static str,
+        matchers: &[Box<dyn Matcher>],
+    ) -> bool {
+        let inner = self.inner.lock().unwrap();
+        for rec in &inner.calls {
+            if rec.method != method {
+                continue;
+            }
+            if args_match(matchers, &rec.args) {
+                t.errorf(&format!(
+                    "expected {method} not to have been called with matching arguments"
+                ));
+                t.fail_now();
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn assert_number_of_calls(&self, t: &dyn TestingT, method: &'static str, n: usize) -> bool {
+        let inner = self.inner.lock().unwrap();
+        let c = inner.calls.iter().filter(|r| r.method == method).count();
+        if c != n {
+            t.errorf(&format!("expected {n} calls to {method}, got {c}"));
+            t.fail_now();
+            return false;
+        }
+        true
+    }
+}
+
+pub fn assert_expectations_for_objects(t: &dyn TestingT, mocks: &[&Mock]) -> bool {
+    for m in mocks {
+        if !m.assert_expectations(t) {
+            return false;
+        }
+    }
+    true
+}
+
+fn args_match(matchers: &[Box<dyn Matcher>], args: &[Box<dyn Any + Send>]) -> bool {
+    if matchers.len() != args.len() {
+        return false;
+    }
+    matchers
+        .iter()
+        .zip(args.iter())
+        .all(|(m, a)| m.matches(a.as_ref()))
+}
+
+#[macro_export]
+macro_rules! mock_args {
+    () => {
+        $crate::mock::Arguments::from_boxes(::std::vec::Vec::new())
+    };
+    ($($x:expr),+ $(,)?) => {{
+        let mut v = ::std::vec::Vec::new();
+        $(
+            v.push(
+                ::std::boxed::Box::new($x) as ::std::boxed::Box<dyn ::std::any::Any + Send>
+            );
+        )*
+        $crate::mock::Arguments::from_boxes(v)
+    }};
+}
+
+#[cfg(test)]
+mod mock_test;

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -1,18 +1,67 @@
+//! Test doubles with **expectations** and **call recording**, in the spirit of Go’s
+//! [testify/mock](https://pkg.go.dev/github.com/stretchr/testify/mock).
+//!
+//! # Model
+//!
+//! 1. Create a [`Mock`] and register expectations with [`Mock::on`] → [`CallBuilder::returning`],
+//!    then finalize with [`PostReturn::finish`], [`PostReturn::once`], [`PostReturn::maybe`], etc.
+//! 2. From your test double, invoke [`Mock::method_called`] with a logical method name and
+//!    [`Arguments`] built with [`mock_args!`] ([`crate::mock_args`]) or [`Arguments::from_boxes`].
+//! 3. Read return values from the returned [`Arguments`] (e.g. [`Arguments::string`],
+//!    [`Arguments::int`]).
+//! 4. Verify with [`Mock::assert_expectations`] and related helpers, passing a [`TestingT`]
+//!    implementation that forwards failures to your test output.
+//!
+//! Unexpected calls **panic** from [`Mock::method_called`]. Failed assertions return `false` and
+//! invoke [`TestingT::errorf`] / [`TestingT::fail_now`].
+//!
+//! # Imports
+//!
+//! ```no_run
+//! use suitecase::mock::{eq, Mock, TestingT};
+//! use suitecase::mock_args;
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use suitecase::mock::{eq, Mock, TestingT};
+//!
+//! struct NoopT;
+//! impl TestingT for NoopT {
+//!     fn errorf(&self, _: &str) {}
+//!     fn fail_now(&self) {}
+//! }
+//!
+//! let m = Mock::new();
+//! m.on("greet", vec![eq("Ada".to_string())])
+//!     .returning(|| vec![Box::new("Hello, Ada".to_string())])
+//!     .finish();
+//!
+//! let out = m.method_called("greet", suitecase::mock_args!("Ada".to_string()));
+//! assert_eq!(out.string(0), "Hello, Ada");
+//! assert!(m.assert_expectations(&NoopT));
+//! ```
+
 mod arguments;
 mod matchers;
 
 pub use arguments::{Arguments, TestingT};
-pub use matchers::{anything, anything_of_type, eq, matched_by};
+pub use matchers::{anything, anything_of_type, eq, matched_by, Matcher};
 
 use std::any::Any;
 use std::sync::Mutex;
 use std::time::Duration;
 
 use arguments::Arguments as Args;
-use matchers::Matcher;
 
 type RunHook = Box<dyn Fn(&Args) + Send + 'static>;
 
+/// Call recorder and expectation registry. Thread-safe (`Mutex`); safe to share across threads.
+///
+/// # Examples
+///
+/// See the [module documentation](self).
 pub struct Mock {
     inner: Mutex<MockInner>,
 }
@@ -47,12 +96,15 @@ enum ReturnGen {
     Fn(Box<dyn Fn() -> Vec<Box<dyn Any + Send>> + Send + 'static>),
 }
 
+/// First step after [`Mock::on`]: call [`CallBuilder::returning`] to supply return values.
 pub struct CallBuilder<'a> {
     mock: &'a Mock,
     method: &'static str,
     matchers: Vec<Box<dyn Matcher>>,
 }
 
+/// Builder after [`CallBuilder::returning`]: add [`PostReturn::run`], [`PostReturn::after`], then
+/// commit with [`PostReturn::finish`], [`PostReturn::once`], [`PostReturn::times`], [`PostReturn::maybe`], …
 pub struct PostReturn<'a, F>
 where
     F: Fn() -> Vec<Box<dyn Any + Send>> + Send + 'static,
@@ -69,12 +121,15 @@ where
     assert_exact: Option<u32>,
 }
 
+/// Handle returned after committing an expectation; call [`ActiveExpectation::unset`] to remove it.
 pub struct ActiveExpectation<'a> {
     mock: &'a Mock,
     id: usize,
 }
 
 impl<'a> CallBuilder<'a> {
+    /// Each invocation of the returned closure produces a fresh vector of return values (boxed as
+    /// [`Any`](std::any::Any)).
     pub fn returning<F>(self, f: F) -> PostReturn<'a, F>
     where
         F: Fn() -> Vec<Box<dyn Any + Send>> + Send + 'static,
@@ -98,16 +153,19 @@ impl<'a, F> PostReturn<'a, F>
 where
     F: Fn() -> Vec<Box<dyn Any + Send>> + Send + 'static,
 {
+    /// Runs before the return closure; receives the same [`Arguments`] as the call.
     pub fn run<R: Fn(&Args) + Send + 'static>(mut self, r: R) -> Self {
         self.run = Some(Box::new(r));
         self
     }
 
+    /// Sleeps for `d` on the calling thread before returning (after the run hook, if any).
     pub fn after(mut self, d: Duration) -> Self {
         self.delay = Some(d);
         self
     }
 
+    /// This expectation does not need to be invoked for [`Mock::assert_expectations`] to pass.
     pub fn maybe(mut self) -> ActiveExpectation<'a> {
         self.maybe = true;
         self.remaining = None;
@@ -115,34 +173,40 @@ where
         self.commit()
     }
 
+    /// Exactly one matching call allowed; assertion requires exactly one invocation.
     pub fn once(mut self) -> ActiveExpectation<'a> {
         self.remaining = Some(1);
         self.assert_exact = Some(1);
         self.commit()
     }
 
+    /// Exactly two matching calls.
     pub fn twice(mut self) -> ActiveExpectation<'a> {
         self.remaining = Some(2);
         self.assert_exact = Some(2);
         self.commit()
     }
 
+    /// Exactly `n` matching calls.
     pub fn times(mut self, n: u32) -> ActiveExpectation<'a> {
         self.remaining = Some(n);
         self.assert_exact = Some(n);
         self.commit()
     }
 
+    /// Unbounded repeat uses of this expectation; assertion still requires at least one call.
     pub fn unlimited(mut self) -> ActiveExpectation<'a> {
         self.remaining = None;
         self.assert_exact = None;
         self.commit()
     }
 
+    /// Same as [`PostReturn::unlimited`].
     pub fn finish(self) -> ActiveExpectation<'a> {
         self.unlimited()
     }
 
+    /// The mocked call panics with `msg` instead of returning values.
     pub fn panic(mut self, msg: impl Into<String>) -> ActiveExpectation<'a> {
         self.panic_msg = Some(msg.into());
         self.remaining = Some(1);
@@ -177,6 +241,7 @@ where
 }
 
 impl ActiveExpectation<'_> {
+    /// Removes this expectation so it no longer matches or counts toward assertions.
     pub fn unset(self) {
         let mut inner = self.mock.inner.lock().unwrap();
         for e in &mut inner.expectations {
@@ -195,6 +260,7 @@ impl Default for Mock {
 }
 
 impl Mock {
+    /// Creates an empty mock with no expectations.
     pub fn new() -> Self {
         Self {
             inner: Mutex::new(MockInner {
@@ -205,6 +271,21 @@ impl Mock {
         }
     }
 
+    /// Starts an expectation for `method` with one matcher per argument passed to
+    /// [`Mock::method_called`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use suitecase::mock::{eq, Mock};
+    ///
+    /// let m = Mock::new();
+    /// m.on("add", vec![eq(1i32), eq(2i32)])
+    ///     .returning(|| vec![Box::new(3i32)])
+    ///     .finish();
+    /// let out = m.method_called("add", suitecase::mock_args!(1i32, 2i32));
+    /// assert_eq!(out.int(0), 3);
+    /// ```
     pub fn on<'a>(
         &'a self,
         method: &'static str,
@@ -217,6 +298,13 @@ impl Mock {
         }
     }
 
+    /// Records a call, finds a matching expectation, runs optional hooks, and returns the values
+    /// from the expectation’s return closure.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no expectation matches, or if the expectation was configured with
+    /// [`PostReturn::panic`].
     pub fn method_called(&self, method: &'static str, args: Args) -> Args {
         let (sleep, panic_m, out) = {
             let mut inner = self.inner.lock().unwrap();
@@ -273,6 +361,28 @@ impl Mock {
         Args::from_boxes(out)
     }
 
+    /// Ensures every non-[`PostReturn::maybe`] expectation was satisfied (invocation counts).
+    ///
+    /// Returns `false` and notifies `t` on the first failure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use suitecase::mock::{Mock, TestingT};
+    ///
+    /// struct T;
+    /// impl TestingT for T {
+    ///     fn errorf(&self, _: &str) {}
+    ///     fn fail_now(&self) {}
+    /// }
+    ///
+    /// let m = Mock::new();
+    /// m.on("x", vec![])
+    ///     .returning(|| vec![Box::new(())])
+    ///     .finish();
+    /// m.method_called("x", suitecase::mock_args!());
+    /// assert!(m.assert_expectations(&T));
+    /// ```
     pub fn assert_expectations(&self, t: &dyn TestingT) -> bool {
         let inner = self.inner.lock().unwrap();
         for exp in &inner.expectations {
@@ -295,6 +405,7 @@ impl Mock {
         true
     }
 
+    /// Returns `true` if some recorded call matches `method` and all `matchers`.
     pub fn assert_called(
         &self,
         t: &dyn TestingT,
@@ -317,6 +428,7 @@ impl Mock {
         false
     }
 
+    /// Returns `true` if no recorded call matches `method` and all `matchers`.
     pub fn assert_not_called(
         &self,
         t: &dyn TestingT,
@@ -339,6 +451,7 @@ impl Mock {
         true
     }
 
+    /// Counts recorded calls whose method name equals `method` (all argument patterns).
     pub fn assert_number_of_calls(&self, t: &dyn TestingT, method: &'static str, n: usize) -> bool {
         let inner = self.inner.lock().unwrap();
         let c = inner.calls.iter().filter(|r| r.method == method).count();
@@ -351,6 +464,27 @@ impl Mock {
     }
 }
 
+/// Runs [`Mock::assert_expectations`] on each mock in order; stops at the first failure.
+///
+/// # Examples
+///
+/// ```
+/// use suitecase::mock::{Mock, TestingT};
+///
+/// struct T;
+/// impl TestingT for T {
+///     fn errorf(&self, _: &str) {}
+///     fn fail_now(&self) {}
+/// }
+///
+/// let a = Mock::new();
+/// let b = Mock::new();
+/// a.on("a", vec![]).returning(|| vec![Box::new(())]).finish();
+/// b.on("b", vec![]).returning(|| vec![Box::new(())]).finish();
+/// a.method_called("a", suitecase::mock_args!());
+/// b.method_called("b", suitecase::mock_args!());
+/// assert!(suitecase::mock::assert_expectations_for_objects(&T, &[&a, &b]));
+/// ```
 pub fn assert_expectations_for_objects(t: &dyn TestingT, mocks: &[&Mock]) -> bool {
     for m in mocks {
         if !m.assert_expectations(t) {
@@ -370,6 +504,20 @@ fn args_match(matchers: &[Box<dyn Matcher>], args: &[Box<dyn Any + Send>]) -> bo
         .all(|(m, a)| m.matches(a.as_ref()))
 }
 
+/// Builds [`Arguments`] from a list of expressions, each boxed as [`Any`](std::any::Any) + [`Send`].
+///
+/// Also available as [`suitecase::mock_args`] at the crate root (via [`macro_export`]).
+///
+/// # Examples
+///
+/// ```
+/// use suitecase::mock::Arguments;
+///
+/// let a = suitecase::mock_args!(1i32, true, "hi".to_string());
+/// assert_eq!(a.len(), 3);
+/// let empty = suitecase::mock_args!();
+/// assert!(empty.is_empty());
+/// ```
 #[macro_export]
 macro_rules! mock_args {
     () => {


### PR DESCRIPTION
This PR adds support for a new mocking module which is inspired by testify/mock from golang  https://pkg.go.dev/github.com/stretchr/testify/mock

Example

```rust
  use suitecase::mock::{eq, Mock, TestingT};
  
  struct NoopT;
  impl TestingT for NoopT {
      fn errorf(&self, _: &str) {}
      fn fail_now(&self) {}
  }
  
  let m = Mock::new();
  
  m.on("greet", vec![eq("Ada".to_string())])
      .returning(|| vec![Box::new("Hello, Ada".to_string())])
      .finish();
  
  let out = m.method_called("greet", suitecase::mock_args!("Ada".to_string()));
  
  assert_eq!(out.string(0), "Hello, Ada");
  
  assert!(m.assert_expectations(&NoopT));
  
```

Assisted-by: Cursor:Composer 2 Fast

Composer was used to convert tho port testify/mock and then changes that was necessary was made to the code. I also used composer to generate the examples/mock.rs