### PR TITLE
feat: case selection, dependencies, fail/fail_now, and CLI --case flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +959,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1378,7 @@ name = "suitecase"
 version = "0.0.10"
 dependencies = [
  "clap",
+ "regex",
  "serde_json",
  "sqlx",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,7 @@ dependencies = [
  "clap",
  "serde_json",
  "sqlx",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+thiserror = "2.0.18"
 
 [[bin]]
 name = "suitecase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+regex = "1"
 thiserror = "2.0.18"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Heavy development:** The API is still evolving. Expect **breaking changes** between releases until a stable 1.0; pin an exact version (or git revision) in `Cargo.toml` if you need upgrades to be predictable.
 
-**Install · [Usage](#usage) · [CLI](#cli) · [Assertions](#assertions-assert) · [Mocking](#mocking-mock) · [Examples](#examples) · [AI-assisted changes](AI_USAGE.md) · [Docs](https://docs.rs/suitecase)** (after publish; `cargo doc --open` locally)
+**Install · [Usage](#usage) · [CLI](#cli) · [Case Selection](#case-selection) · [Dependencies](#case-dependencies-depends_on) · [Fail](#fail-and-fail_now) · [Assertions](#assertions-assert) · [Mocking](#mocking-mock) · [Examples](#examples) · [AI-assisted changes](AI_USAGE.md) · [Docs](https://docs.rs/suitecase)** (after publish; `cargo doc --open` locally)
 
 ---
 
@@ -12,6 +12,7 @@
 - **Sequential execution** — [`test_suite!`](https://docs.rs/suitecase/latest/suitecase/macro.test_suite.html) emits **one** `#[test]` that runs all cases in slice order. Cases that depend on earlier state (setup → mutate → assert) always execute correctly.
 - **Formatted output** — Each case prints `▶ name`, then `✓ name (Xms)` or `✗ name (Xms)`. All cases run even if one fails; the first panic is re-raised after completion.
 - **Hooks as optional fns** — [`HookFns`](https://docs.rs/suitecase/latest/suitecase/suite/struct.HookFns.html) holds `Option<fn(&mut S)>` per lifecycle slot; use [`None`] to skip.
+- **Case selection** — [`RunConfig::filter`](https://docs.rs/suitecase/latest/suitecase/suite/struct.RunConfig.html#method.filter), [`RunConfig::filters`](https://docs.rs/suitecase/latest/suitecase/suite/struct.RunConfig.html#method.filters), and [`RunConfig::pattern`](https://docs.rs/suitecase/latest/suitecase/suite/struct.RunConfig.html#method.pattern) let you run a single case, a group, or a glob match. Dependencies declared via `depends_on` are auto-included.
 - **CLI** — `suitecase test` runs `suitecase test` and renders a formatted summary with pass/fail counts, per-case timing, and failure details.
 - **Assertions** — [`suitecase::assert`](https://docs.rs/suitecase/latest/suitecase/assert/index.html) provides [testify/assert](https://pkg.go.dev/github.com/stretchr/testify/assert)-style helpers (`equal`, `contains`, `assert_ok`, …) that **panic** on failure with clear messages ([`#[track_caller]`](https://doc.rust-lang.org/stable/std/panic/struct.Location.html) where applicable).
 - **Mocking** — [`suitecase::mock`](https://docs.rs/suitecase/latest/suitecase/mock/index.html) provides [testify/mock](https://pkg.go.dev/github.com/stretchr/testify/mock)-style **expectations** and **call recording** ([`Mock`](https://docs.rs/suitecase/latest/suitecase/mock/struct.Mock.html), [`mock_args!`](https://docs.rs/suitecase/latest/suitecase/macro.mock_args.html)). Use [`suitecase::mock_args`](https://docs.rs/suitecase/latest/suitecase/macro.mock_args.html) at the crate root (same macro).
@@ -110,6 +111,76 @@ Run: `suitecase test`.
 ### Hooks
 
 Pass [`HookFns`](https://docs.rs/suitecase/latest/suitecase/suite/struct.HookFns.html) as the last argument to [`run`](https://docs.rs/suitecase/latest/suitecase/suite/fn.run.html). Each field is `Option<fn(&mut S)>` — [`Some(...)]` or [`None`] / [`HookFns::default()`].
+
+### Case selection
+
+Run a single case, a group, or a glob pattern by passing a [`RunConfig`](https://docs.rs/suitecase/latest/suitecase/suite/struct.RunConfig.html) to [`run`](https://docs.rs/suitecase/latest/suitecase/suite/fn.run.html). Hooks (`setup_suite`, `teardown_suite`, `before_each`, `after_each`) still execute for selected cases.
+
+```rust
+use suitecase::{cases, run, Case, HookFns, RunConfig};
+
+#[derive(Default)]
+struct Counter { n: i32 }
+
+static CASES: &[Case<Counter>] = cases![Counter, s =>
+    test_a => { s.n = 1; },
+    test_b => { s.n = 2; },
+    test_c => { s.n = 3; },
+];
+
+// Single case
+run(&mut Counter::default(), CASES, RunConfig::filter("test_b"), &HookFns::default());
+
+// Multiple cases
+run(&mut Counter::default(), CASES, RunConfig::filters(["test_a".to_string(), "test_c".to_string()]), &HookFns::default());
+
+// Glob pattern (* matches any characters)
+run(&mut Counter::default(), CASES, RunConfig::pattern("test_*"), &HookFns::default());
+```
+
+### Case dependencies (`depends_on`)
+
+Declare that a case requires other cases to run first. When you filter to a case with dependencies, those dependencies are automatically included and run in topological order.
+
+```rust
+use suitecase::{cases, run, Case, HookFns, RunConfig};
+
+#[derive(Default)]
+struct Db { connected: bool, migrated: bool }
+
+static CASES: &[Case<Db>] = cases![Db, s =>
+    connect => { s.connected = true; },
+    migrate(depends_on = [connect]) => { s.migrated = true; },
+    query(depends_on = [migrate]) => { assert!(s.connected && s.migrated); },
+];
+
+// Running only "query" auto-includes connect → migrate → query
+let mut db = Db::default();
+run(&mut db, CASES, RunConfig::filter("query"), &HookFns::default());
+```
+
+Circular dependencies and missing dependencies **panic** at runtime.
+
+### Fail and fail_now
+
+Use [`suitecase::fail`](https://docs.rs/suitecase/latest/suitecase/fn.fail.html) and [`suitecase::fail_now`](https://docs.rs/suitecase/latest/suitecase/fn.fail_now.html) inside case bodies:
+
+- **`fail(msg)`** — marks the current case as failed, **continues** running remaining cases, exits cleanly (no re-panic).
+- **`fail_now(msg)`** — marks the current case as failed, **aborts** all remaining cases, runs `teardown_suite`, then panics.
+
+If a case fails via either function, cases that depend on it (via `depends_on`) are **skipped** (shown as `⊘`).
+
+```rust
+use suitecase::{cases, run, Case, HookFns, RunConfig, fail};
+
+#[derive(Default)]
+struct App { ready: bool }
+
+static CASES: &[Case<App>] = cases![App, s =>
+    setup => { s.ready = true; },
+    check => { if !s.ready { fail("not ready"); } },
+];
+```
 
 ### Sequential test suite (`test_suite!`)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ suitecase test --example sqlx_sqlite
 suitecase test --lib -- shared_state    # filter by test name
 ```
 
+### Filtering individual cases
+
+Use `--case` to run a single case or a group of cases within a suite. Supports exact match, glob (`*`), and full regex:
+
+```sh
+suitecase test --lib --case "test_inc"           # exact match
+suitecase test --lib --case "test_*"             # glob pattern
+suitecase test --lib --case "^test_.*_verify$"   # regex
+```
+
+To enable CLI case filtering, use `RunConfig::from_args()` in your test code:
+
+```rust
+#[test]
+fn my_suite() {
+    let mut suite = MySuite::default();
+    run(&mut suite, CASES, RunConfig::from_args(), &HookFns::default());
+}
+```
+
+If `--case` is not provided, `RunConfig::from_args()` falls back to running all cases.
+
 Output:
 
 ```

--- a/src/bin/suitecase/bin.rs
+++ b/src/bin/suitecase/bin.rs
@@ -36,6 +36,10 @@ enum Commands {
         #[arg(long)]
         release: bool,
 
+        /// Filter cases by name (supports regex, e.g. "^test_.*_verify$")
+        #[arg(long)]
+        case: Option<String>,
+
         /// Arguments passed directly to cargo test
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
         args: Vec<String>,
@@ -51,8 +55,9 @@ fn main() {
             output,
             workspace,
             release,
+            case,
         } => {
-            test::run(args, output, workspace, release);
+            test::run(args, output, workspace, release, case);
         }
     }
 }

--- a/src/bin/suitecase/test.rs
+++ b/src/bin/suitecase/test.rs
@@ -47,7 +47,7 @@ struct PanicInfo {
     message: String,
 }
 
-pub fn run(args: Vec<String>, output: OutputMode, workspace: bool, release: bool) {
+pub fn run(args: Vec<String>, output: OutputMode, workspace: bool, release: bool, case: Option<String>) {
     let (cargo_args, test_args) = split_at_double_dash(&args);
 
     let mut cmd = Command::new("cargo");
@@ -63,6 +63,10 @@ pub fn run(args: Vec<String>, output: OutputMode, workspace: bool, release: bool
     }
     cmd.arg("--");
     cmd.arg("--nocapture");
+    if let Some(ref c) = case {
+        cmd.arg("--case");
+        cmd.arg(c);
+    }
     for arg in &test_args {
         cmd.arg(arg);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,4 +57,4 @@ pub mod assert;
 pub mod mock;
 pub mod suite;
 
-pub use suite::{Case, HookFns, RunConfig, run};
+pub use suite::{fail, fail_now, Case, HookFns, RunConfig, run};

--- a/src/suite/fail.rs
+++ b/src/suite/fail.rs
@@ -1,3 +1,5 @@
+use std::panic::panic_any;
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -5,14 +7,30 @@ pub enum FailReason {
     #[error("Fail: {0}")]
     Fail(String),
 
-    #[error("Fail: {0}")]
+    #[error("FailNow: {0}")]
     FailNow(String),
 }
 
-pub fn fail(reason: String) -> FailReason {
-    FailReason::Fail(reason)
+/// Mark the current case as failed; remaining cases continue.
+///
+/// # Panics
+///
+/// Always panics with a [`FailReason::Fail`]. The runner catches this and records
+/// the case as failed without re-panicking.
+#[track_caller]
+pub fn fail(reason: &str) -> ! {
+    panic_any(FailReason::Fail(reason.to_string()))
 }
 
-pub fn fail_now(reason: String) -> FailReason {
-    FailReason::FailNow(reason)
+/// Mark the current case as failed and abort all remaining cases.
+///
+/// The runner catches this, records the case as failed, runs `teardown_suite`
+/// if present, then panics with the message.
+///
+/// # Panics
+///
+/// Always panics with a [`FailReason::FailNow`].
+#[track_caller]
+pub fn fail_now(reason: &str) -> ! {
+    panic_any(FailReason::FailNow(reason.to_string()))
 }

--- a/src/suite/fail.rs
+++ b/src/suite/fail.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum FailReason {
+    #[error("Fail: {0}")]
+    Fail(String),
+
+    #[error("Fail: {0}")]
+    FailNow(String),
+}
+
+pub fn fail(reason: String) -> FailReason {
+    FailReason::Fail(reason)
+}
+
+pub fn fail_now(reason: String) -> FailReason {
+    FailReason::FailNow(reason)
+}

--- a/src/suite/fail_test.rs
+++ b/src/suite/fail_test.rs
@@ -1,0 +1,105 @@
+use crate::{Case, HookFns, RunConfig, run, fail, fail_now};
+
+#[derive(Default)]
+struct FailRecorder {
+    log: Vec<&'static str>,
+}
+
+impl FailRecorder {
+    fn push(&mut self, e: &'static str) {
+        self.log.push(e);
+    }
+}
+
+fn fr_setup(s: &mut FailRecorder) {
+    s.push("setup_suite");
+}
+fn fr_teardown(s: &mut FailRecorder) {
+    s.push("teardown_suite");
+}
+
+static FAIL_HOOKS: HookFns<FailRecorder> = HookFns {
+    setup_suite: Some(fr_setup),
+    teardown_suite: Some(fr_teardown),
+    before_each: None,
+    after_each: None,
+};
+
+#[test]
+fn fail_marks_case_failed_and_continues() {
+    let mut suite = FailRecorder::default();
+    static CASES: &[Case<FailRecorder>] = cases![FailRecorder, s =>
+        first => { s.push("first"); },
+        second => { fail("expected failure"); },
+        third => { s.push("third"); },
+    ];
+    run(&mut suite, CASES, RunConfig::all(), &FAIL_HOOKS);
+    assert_eq!(
+        suite.log,
+        vec!["setup_suite", "first", "third", "teardown_suite"]
+    );
+}
+
+#[test]
+fn fail_now_aborts_remaining_cases() {
+    let mut suite = FailRecorder::default();
+    static CASES: &[Case<FailRecorder>] = cases![FailRecorder, s =>
+        first => { s.push("first"); },
+        second => { fail_now("abort here"); },
+        third => { s.push("third"); },
+    ];
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run(&mut suite, CASES, RunConfig::all(), &FAIL_HOOKS);
+    }));
+    assert!(err.is_err());
+    assert_eq!(
+        suite.log,
+        vec!["setup_suite", "first", "teardown_suite"]
+    );
+}
+
+#[test]
+fn fail_now_runs_teardown() {
+    let mut suite = FailRecorder::default();
+    static CASES: &[Case<FailRecorder>] = cases![FailRecorder, s =>
+        only => { fail_now("abort"); },
+    ];
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run(&mut suite, CASES, RunConfig::all(), &FAIL_HOOKS);
+    }));
+    assert!(err.is_err());
+    assert_eq!(suite.log, vec!["setup_suite", "teardown_suite"]);
+}
+
+#[test]
+fn multiple_fail_only_first_records() {
+    let mut suite = FailRecorder::default();
+    static CASES: &[Case<FailRecorder>] = cases![FailRecorder, s =>
+        a => { fail("first fail"); },
+        b => { fail("second fail"); },
+        c => { s.push("c"); },
+    ];
+    run(&mut suite, CASES, RunConfig::all(), &FAIL_HOOKS);
+    assert_eq!(
+        suite.log,
+        vec!["setup_suite", "c", "teardown_suite"]
+    );
+}
+
+#[test]
+fn regular_panic_still_re_raises() {
+    let mut suite = FailRecorder::default();
+    static CASES: &[Case<FailRecorder>] = cases![FailRecorder, s =>
+        first => { s.push("first"); },
+        second => { panic!("regular panic"); },
+        third => { s.push("third"); },
+    ];
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run(&mut suite, CASES, RunConfig::all(), &FAIL_HOOKS);
+    }));
+    assert!(err.is_err());
+    assert_eq!(
+        suite.log,
+        vec!["setup_suite", "first", "third", "teardown_suite"]
+    );
+}

--- a/src/suite/mod.rs
+++ b/src/suite/mod.rs
@@ -29,6 +29,9 @@
 //!
 //! Any hook that is [`None`] is skipped.
 
+mod fail;
+pub use fail::{fail, fail_now};
+
 /// Optional lifecycle callbacks. Each field is [`Some`] with a function to run at that point, or
 /// [`None`] to skip.
 ///

--- a/src/suite/mod.rs
+++ b/src/suite/mod.rs
@@ -33,6 +33,8 @@ mod fail;
 use fail::FailReason;
 pub use fail::{fail, fail_now};
 
+use regex::Regex;
+
 /// Optional lifecycle callbacks. Each field is [`Some`] with a function to run at that point, or
 /// [`None`] to skip.
 ///
@@ -130,6 +132,38 @@ impl RunConfig {
             pattern: Some(pat.into()),
         }
     }
+
+    /// Reads `--case <pattern>` from `std::env::args()` and returns a config
+    /// that filters cases by regex or glob. Falls back to [`RunConfig::all`] if not found.
+    ///
+    /// If the pattern contains regex metacharacters (`^`, `$`, `.`, `+`, `?`, `(`, `)`,
+    /// `[`, `]`, `{`, `|`), it is treated as a regex. Otherwise it is treated as a glob
+    /// (`*` matches any characters).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use suitecase::{cases, run, Case, HookFns, RunConfig};
+    ///
+    /// #[derive(Default)]
+    /// struct Counter { n: i32 }
+    ///
+    /// static CASES: &[Case<Counter>] = cases![Counter, s =>
+    ///     test_inc => { s.n += 1; },
+    /// ];
+    ///
+    /// let mut suite = Counter::default();
+    /// run(&mut suite, CASES, RunConfig::from_args(), &HookFns::default());
+    /// ```
+    pub fn from_args() -> Self {
+        let args: Vec<String> = std::env::args().collect();
+        for i in 0..args.len() {
+            if args[i] == "--case" && i + 1 < args.len() {
+                return Self::pattern(&args[i + 1]);
+            }
+        }
+        Self::all()
+    }
 }
 
 /// Run the selected cases on `suite` using `hooks` for lifecycle callbacks.
@@ -201,7 +235,7 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
                     return true;
                 }
                 if let Some(ref pat) = config.pattern {
-                    return glob_match(pat, c.name);
+                    return pattern_match(pat, c.name);
                 }
                 false
             })
@@ -341,6 +375,21 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
     if let Some(payload) = first_panic {
         std::panic::resume_unwind(payload);
     }
+}
+
+fn pattern_match(pattern: &str, name: &str) -> bool {
+    if is_regex_pattern(pattern) {
+        match Regex::new(pattern) {
+            Ok(re) => re.is_match(name),
+            Err(_) => false,
+        }
+    } else {
+        glob_match(pattern, name)
+    }
+}
+
+fn is_regex_pattern(pattern: &str) -> bool {
+    pattern.chars().any(|c| matches!(c, '^' | '$' | '.' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '|'))
 }
 
 fn glob_match(pattern: &str, name: &str) -> bool {

--- a/src/suite/mod.rs
+++ b/src/suite/mod.rs
@@ -30,6 +30,7 @@
 //! Any hook that is [`None`] is skipped.
 
 mod fail;
+use fail::FailReason;
 pub use fail::{fail, fail_now};
 
 /// Optional lifecycle callbacks. Each field is [`Some`] with a function to run at that point, or
@@ -167,6 +168,8 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
 
     setup_suite(suite);
     let mut first_panic: Option<Box<dyn std::any::Any + Send>> = None;
+    let mut fail_msg: Option<String> = None;
+    let mut fail_now_msg: Option<String> = None;
     for case in selected {
         println!("▶ {}", case.name);
         let start = std::time::Instant::now();
@@ -178,15 +181,36 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
         let elapsed = start.elapsed();
         let ms = elapsed.as_millis();
         if let Err(payload) = case_result {
-            println!("✗ {} ({}ms)", case.name, ms);
-            if first_panic.is_none() {
-                first_panic = Some(payload);
+            if let Some(reason) = payload.downcast_ref::<FailReason>() {
+                match reason {
+                    FailReason::Fail(msg) => {
+                        println!("✗ {} ({}ms)", case.name, ms);
+                        if fail_msg.is_none() {
+                            fail_msg = Some(msg.clone());
+                        }
+                    }
+                    FailReason::FailNow(msg) => {
+                        println!("✗ {} ({}ms)", case.name, ms);
+                        if fail_now_msg.is_none() {
+                            fail_now_msg = Some(msg.clone());
+                        }
+                        break;
+                    }
+                }
+            } else {
+                println!("✗ {} ({}ms)", case.name, ms);
+                if first_panic.is_none() {
+                    first_panic = Some(payload);
+                }
             }
         } else {
             println!("✓ {} ({}ms)", case.name, ms);
         }
     }
     teardown_suite(suite);
+    if let Some(msg) = fail_now_msg {
+        panic!("suitecase: {}", msg);
+    }
     if let Some(payload) = first_panic {
         std::panic::resume_unwind(payload);
     }
@@ -242,7 +266,7 @@ macro_rules! cases {
 ///
 /// ```text
 /// test_suite! {
-///     $ty:ty, $storage:ident, $init:expr, $hooks:expr, $s:ident =>
+///     $ty:ty, $storage:ident, $test:ident, $init:expr, $hooks:expr, $s:ident =>
 ///         $($name:ident => $body:block),* $(,)?
 /// }
 /// ```
@@ -258,6 +282,27 @@ macro_rules! cases {
 /// test_suite!(
 ///     Counter,
 ///     MY_SUITE,
+///     counter_test,
+///     Counter::default(),
+///     HookFns::default(),
+///     s =>
+///     setup => { s.n = 1; },
+///     verify => { assert_eq!(s.n, 1); },
+/// );
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use suitecase::{test_suite, HookFns};
+///
+/// #[derive(Default)]
+/// struct Counter { n: i32 }
+///
+/// test_suite!(
+///     Counter,
+///     MY_SUITE_2,
+///     counter_test_2,
 ///     Counter::default(),
 ///     HookFns::default(),
 ///     s =>
@@ -301,3 +346,6 @@ mod shared_state_test;
 
 #[cfg(test)]
 mod cargo_filter_output_test;
+
+#[cfg(test)]
+mod fail_test;

--- a/src/suite/mod.rs
+++ b/src/suite/mod.rs
@@ -74,11 +74,16 @@ impl<S> HookFns<S> {
 pub struct Case<S> {
     pub name: &'static str,
     pub run: fn(&mut S),
+    pub dependencies: &'static [&'static str],
 }
 
 impl<S> Case<S> {
     pub const fn new(name: &'static str, run: fn(&mut S)) -> Self {
-        Self { name, run }
+        Self {
+            name,
+            run,
+            dependencies: &[],
+        }
     }
 }
 
@@ -87,6 +92,10 @@ impl<S> Case<S> {
 pub struct RunConfig {
     /// When set, only the case whose name matches **exactly** runs.
     pub filter: Option<String>,
+    /// When set, only cases whose names appear in this list run.
+    pub filters: Vec<String>,
+    /// When set, only cases whose names match this glob pattern run (`*` matches any chars).
+    pub pattern: Option<String>,
 }
 
 impl RunConfig {
@@ -99,6 +108,26 @@ impl RunConfig {
     pub fn filter(name: impl Into<String>) -> Self {
         Self {
             filter: Some(name.into()),
+            filters: Vec::new(),
+            pattern: None,
+        }
+    }
+
+    /// Run only cases whose names appear in `names`.
+    pub fn filters(names: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            filter: None,
+            filters: names.into_iter().collect(),
+            pattern: None,
+        }
+    }
+
+    /// Run only cases whose names match the glob `pat` (`*` matches any characters).
+    pub fn pattern(pat: impl Into<String>) -> Self {
+        Self {
+            filter: None,
+            filters: Vec::new(),
+            pattern: Some(pat.into()),
         }
     }
 }
@@ -149,19 +178,101 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
     FB: FnMut(&mut S),
     FA: FnMut(&mut S),
 {
-    let selected: Vec<&Case<S>> = cases
-        .iter()
-        .filter(|c| match &config.filter {
-            None => true,
-            Some(f) => c.name == f,
-        })
-        .collect();
+    let has_filter = config.filter.is_some()
+        || !config.filters.is_empty()
+        || config.pattern.is_some();
+
+    let selected: Vec<&Case<S>> = if !has_filter {
+        cases.iter().collect()
+    } else {
+        let mut names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+
+        if let Some(ref f) = config.filter {
+            names.insert(f.as_str());
+        }
+        for f in &config.filters {
+            names.insert(f.as_str());
+        }
+
+        let direct: Vec<&Case<S>> = cases
+            .iter()
+            .filter(|c| {
+                if names.contains(c.name) {
+                    return true;
+                }
+                if let Some(ref pat) = config.pattern {
+                    return glob_match(pat, c.name);
+                }
+                false
+            })
+            .collect();
+
+        let mut resolved: Vec<&Case<S>> = Vec::new();
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut visiting: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let all_names: std::collections::HashMap<&str, &Case<S>> =
+            cases.iter().map(|c| (c.name, c)).collect();
+
+        for case in &direct {
+            resolve_deps(case, &all_names, &mut resolved, &mut seen, &mut visiting);
+        }
+
+        let resolved_names: std::collections::HashSet<&str> =
+            resolved.iter().map(|c| c.name).collect();
+
+        let mut in_degree: std::collections::HashMap<&str, usize> = resolved_names
+            .iter()
+            .map(|n| (*n, 0))
+            .collect();
+
+        for case in &resolved {
+            for dep in case.dependencies {
+                if resolved_names.contains(*dep) {
+                    *in_degree.entry(case.name).or_insert(0) += 1;
+                }
+            }
+        }
+
+        let order_map: std::collections::HashMap<&str, usize> =
+            cases.iter().enumerate().map(|(i, c)| (c.name, i)).collect();
+
+        let mut result: Vec<&Case<S>> = Vec::new();
+        let mut resolved_case_map: std::collections::HashMap<&str, &Case<S>> =
+            resolved.iter().map(|c| (c.name, *c)).collect();
+
+        loop {
+            let mut available: Vec<&str> = in_degree
+                .iter()
+                .filter(|(_, deg)| **deg == 0)
+                .map(|(&name, _)| name)
+                .collect();
+            if available.is_empty() {
+                break;
+            }
+            available.sort_by_key(|n| order_map.get(n).copied().unwrap_or(0));
+            let next = available[0];
+            in_degree.remove(next);
+            if let Some(case) = resolved_case_map.remove(next) {
+                result.push(case);
+            }
+            for case in resolved_case_map.values() {
+                for dep in case.dependencies {
+                    if *dep == next {
+                        if let Some(deg) = in_degree.get_mut(case.name) {
+                            *deg = deg.saturating_sub(1);
+                        }
+                    }
+                }
+            }
+        }
+
+        result
+    };
 
     if selected.is_empty() {
         assert!(
-            config.filter.is_none(),
-            "suitcase: filter {:?} matched no cases",
-            config.filter
+            !has_filter,
+            "suitecase: filter matched no cases"
         );
         return;
     }
@@ -170,7 +281,20 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
     let mut first_panic: Option<Box<dyn std::any::Any + Send>> = None;
     let mut fail_msg: Option<String> = None;
     let mut fail_now_msg: Option<String> = None;
-    for case in selected {
+    let mut failed_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut skipped_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+
+    for case in &selected {
+        let deps_failed = case.dependencies.iter().any(|d| {
+            failed_names.contains(*d) || skipped_names.contains(*d)
+        });
+
+        if deps_failed {
+            skipped_names.insert(case.name);
+            println!("⊘ {} (skipped, dependency failed)", case.name);
+            continue;
+        }
+
         println!("▶ {}", case.name);
         let start = std::time::Instant::now();
         before_each(suite);
@@ -185,12 +309,14 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
                 match reason {
                     FailReason::Fail(msg) => {
                         println!("✗ {} ({}ms)", case.name, ms);
+                        failed_names.insert(case.name);
                         if fail_msg.is_none() {
                             fail_msg = Some(msg.clone());
                         }
                     }
                     FailReason::FailNow(msg) => {
                         println!("✗ {} ({}ms)", case.name, ms);
+                        failed_names.insert(case.name);
                         if fail_now_msg.is_none() {
                             fail_now_msg = Some(msg.clone());
                         }
@@ -199,6 +325,7 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
                 }
             } else {
                 println!("✗ {} ({}ms)", case.name, ms);
+                failed_names.insert(case.name);
                 if first_panic.is_none() {
                     first_panic = Some(payload);
                 }
@@ -216,6 +343,70 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
     }
 }
 
+fn glob_match(pattern: &str, name: &str) -> bool {
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.len() == 1 {
+        return pattern == name;
+    }
+    let mut pos = 0;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !name.starts_with(part) {
+                return false;
+            }
+            pos = part.len();
+        } else if i == parts.len() - 1 {
+            if !name[pos..].ends_with(part) {
+                return false;
+            }
+        } else {
+            if let Some(found) = name[pos..].find(part) {
+                pos += found + part.len();
+            } else {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn resolve_deps<'a, S>(
+    case: &'a Case<S>,
+    all: &std::collections::HashMap<&str, &'a Case<S>>,
+    resolved: &mut Vec<&'a Case<S>>,
+    seen: &mut std::collections::HashSet<&'a str>,
+    visiting: &mut std::collections::HashSet<&'a str>,
+) {
+    if seen.contains(case.name) {
+        return;
+    }
+    if visiting.contains(case.name) {
+        let cycle: Vec<&str> = visiting.iter().copied().collect();
+        panic!(
+            "suitecase: circular dependency detected: {} → {}",
+            case.name,
+            cycle.join(" → ")
+        );
+    }
+    visiting.insert(case.name);
+    for dep_name in case.dependencies {
+        let dep = all.get(dep_name).unwrap_or_else(|| {
+            panic!(
+                "suitecase: dependency {:?} of case {:?} not found",
+                dep_name, case.name
+            )
+        });
+        resolve_deps(dep, all, resolved, seen, visiting);
+    }
+    visiting.remove(case.name);
+    if seen.insert(case.name) {
+        resolved.push(case);
+    }
+}
+
 /// Build a `&'static [Case<S>]` from case names and inline blocks.
 ///
 /// # Declaration
@@ -223,6 +414,16 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
 /// ```text
 /// cases! {
 ///     $ty:ty, $s:ident => $($name:ident => $body:block),* $(,)?
+/// }
+/// ```
+///
+/// With dependencies:
+///
+/// ```text
+/// cases! {
+///     $ty:ty, $s:ident =>
+///         $name:ident => $body:block,
+///         $name:ident (depends_on = [$($dep:ident),+]) => $body:block,
 /// }
 /// ```
 ///
@@ -248,10 +449,41 @@ fn run_hooks_with_output<S, FS, FT, FB, FA>(
 /// let mut suite = MySuite::default();
 /// run(&mut suite, cases, RunConfig::all(), &HookFns::default());
 /// ```
+///
+/// # Example with dependencies
+///
+/// ```
+/// use suitecase::{cases, run, Case, HookFns, RunConfig};
+///
+/// #[derive(Default)]
+/// struct MySuite {
+///     n: i32,
+/// }
+///
+/// let cases: &[Case<MySuite>] = cases![MySuite, s =>
+///     setup => { s.n = 1; },
+///     verify(depends_on = [setup]) => { assert_eq!(s.n, 1); },
+/// ];
+/// let mut suite = MySuite::default();
+/// run(&mut suite, cases, RunConfig::filter("verify"), &HookFns::default());
+/// assert_eq!(suite.n, 1);
+/// ```
 #[macro_export]
 macro_rules! cases {
-    ($ty:ty, $s:ident => $($name:ident => $body:block),* $(,)?) => {
-        &[$( $crate::suite::Case::<$ty>::new(stringify!($name), |$s: &mut $ty| $body)),*]
+    ($ty:ty, $s:ident => $($rest:tt)*) => {
+        $crate::cases!(@parse ($ty) ($s) [] $($rest)*)
+    };
+    (@parse ($ty:ty) ($s:ident) [$($out:expr),*] $name:ident (depends_on = [$($dep:ident),+ $(,)?]) => $body:block $(, $($rest:tt)*)?) => {
+        $crate::cases!(@parse ($ty) ($s) [$($out,)* $crate::suite::Case::<$ty> { name: stringify!($name), run: |$s: &mut $ty| $body, dependencies: &[$(stringify!($dep)),+] }] $($($rest)*)?)
+    };
+    (@parse ($ty:ty) ($s:ident) [$($out:expr),*] $name:ident => $body:block $(, $($rest:tt)*)?) => {
+        $crate::cases!(@parse ($ty) ($s) [$($out,)* $crate::suite::Case::<$ty>::new(stringify!($name), |$s: &mut $ty| $body)] $($($rest)*)?)
+    };
+    (@parse ($ty:ty) ($s:ident) [$($out:expr),*] ,) => {
+        &[$($out),*]
+    };
+    (@parse ($ty:ty) ($s:ident) [$($out:expr),*]) => {
+        &[$($out),*]
     };
 }
 
@@ -349,3 +581,6 @@ mod cargo_filter_output_test;
 
 #[cfg(test)]
 mod fail_test;
+
+#[cfg(test)]
+mod selection_test;

--- a/src/suite/selection_test.rs
+++ b/src/suite/selection_test.rs
@@ -1,0 +1,308 @@
+use crate::{Case, HookFns, RunConfig, run, fail, fail_now};
+
+#[derive(Default)]
+struct SelRecorder {
+    log: Vec<&'static str>,
+}
+
+impl SelRecorder {
+    fn push(&mut self, e: &'static str) {
+        self.log.push(e);
+    }
+}
+
+fn sr_setup(s: &mut SelRecorder) {
+    s.push("setup_suite");
+}
+fn sr_teardown(s: &mut SelRecorder) {
+    s.push("teardown_suite");
+}
+fn sr_before(s: &mut SelRecorder) {
+    s.push("before_each");
+}
+fn sr_after(s: &mut SelRecorder) {
+    s.push("after_each");
+}
+
+static SEL_HOOKS: HookFns<SelRecorder> = HookFns {
+    setup_suite: Some(sr_setup),
+    teardown_suite: Some(sr_teardown),
+    before_each: Some(sr_before),
+    after_each: Some(sr_after),
+};
+
+#[test]
+fn single_filter_runs_only_that_case() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        first => { s.push("first"); },
+        second => { s.push("second"); },
+        third => { s.push("third"); },
+    ];
+    run(&mut suite, cases, RunConfig::filter("second"), &SEL_HOOKS);
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "second",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}
+
+#[test]
+fn multiple_filters_run_matching_cases() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        alpha => { s.push("alpha"); },
+        beta => { s.push("beta"); },
+        gamma => { s.push("gamma"); },
+    ];
+    run(
+        &mut suite,
+        cases,
+        RunConfig::filters(["alpha".to_string(), "gamma".to_string()]),
+        &SEL_HOOKS,
+    );
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "alpha",
+            "after_each",
+            "before_each",
+            "gamma",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}
+
+#[test]
+fn glob_pattern_matches_cases() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        test_a => { s.push("test_a"); },
+        test_b => { s.push("test_b"); },
+        other => { s.push("other"); },
+    ];
+    run(
+        &mut suite,
+        cases,
+        RunConfig::pattern("test_*"),
+        &SEL_HOOKS,
+    );
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "test_a",
+            "after_each",
+            "before_each",
+            "test_b",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}
+
+#[test]
+fn glob_pattern_prefix_match() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        setup_db => { s.push("setup_db"); },
+        setup_cache => { s.push("setup_cache"); },
+        teardown => { s.push("teardown"); },
+    ];
+    run(
+        &mut suite,
+        cases,
+        RunConfig::pattern("setup_*"),
+        &SEL_HOOKS,
+    );
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "setup_db",
+            "after_each",
+            "before_each",
+            "setup_cache",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}
+
+#[test]
+fn depends_on_runs_deps_before_target() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        setup => { s.push("setup"); },
+        action(depends_on = [setup]) => { s.push("action"); },
+        verify(depends_on = [action]) => { s.push("verify"); },
+    ];
+    run(
+        &mut suite,
+        cases,
+        RunConfig::filter("verify"),
+        &SEL_HOOKS,
+    );
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "setup",
+            "after_each",
+            "before_each",
+            "action",
+            "after_each",
+            "before_each",
+            "verify",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}
+
+#[test]
+fn depends_on_multiple_deps() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        a => { s.push("a"); },
+        b => { s.push("b"); },
+        c(depends_on = [a, b]) => { s.push("c"); },
+    ];
+    run(
+        &mut suite,
+        cases,
+        RunConfig::filter("c"),
+        &SEL_HOOKS,
+    );
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "a",
+            "after_each",
+            "before_each",
+            "b",
+            "after_each",
+            "before_each",
+            "c",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}
+
+#[test]
+#[should_panic(expected = "dependency")]
+fn missing_dep_panics() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        only(depends_on = [nonexistent]) => { s.push("only"); },
+    ];
+    run(
+        &mut suite,
+        cases,
+        RunConfig::filter("only"),
+        &SEL_HOOKS,
+    );
+}
+
+#[test]
+#[should_panic(expected = "circular dependency")]
+fn circular_dep_panics() {
+    let mut suite = SelRecorder::default();
+    let a = Case::<SelRecorder> { name: "a", run: |s| s.push("a"), dependencies: &["b"] };
+    let b = Case::<SelRecorder> { name: "b", run: |s| s.push("b"), dependencies: &["a"] };
+    let cases: &[Case<SelRecorder>] = &[a, b];
+    run(
+        &mut suite,
+        cases,
+        RunConfig::filter("a"),
+        &SEL_HOOKS,
+    );
+}
+
+#[test]
+fn fail_in_dep_skips_dependents() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        setup => { fail("setup failed"); },
+        action(depends_on = [setup]) => { s.push("action"); },
+        verify(depends_on = [action]) => { s.push("verify"); },
+    ];
+    run(&mut suite, cases, RunConfig::all(), &SEL_HOOKS);
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}
+
+#[test]
+fn fail_now_in_dep_aborts_and_skips_dependents() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        setup => { fail_now("setup abort"); },
+        action(depends_on = [setup]) => { s.push("action"); },
+    ];
+    let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run(&mut suite, cases, RunConfig::all(), &SEL_HOOKS);
+    }));
+    assert!(err.is_err());
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}
+
+#[test]
+fn depends_on_preserves_topological_order() {
+    let mut suite = SelRecorder::default();
+    let cases: &[Case<SelRecorder>] = cases![SelRecorder, s =>
+        z => { s.push("z"); },
+        a => { s.push("a"); },
+        b(depends_on = [a]) => { s.push("b"); },
+    ];
+    run(
+        &mut suite,
+        cases,
+        RunConfig::filters(["z".to_string(), "b".to_string()]),
+        &SEL_HOOKS,
+    );
+    assert_eq!(
+        suite.log,
+        vec![
+            "setup_suite",
+            "before_each",
+            "z",
+            "after_each",
+            "before_each",
+            "a",
+            "after_each",
+            "before_each",
+            "b",
+            "after_each",
+            "teardown_suite",
+        ]
+    );
+}


### PR DESCRIPTION
Closes https://github.com/emilpriver/suitecase/issues/5
Closes https://github.com/emilpriver/suitecase/issues/18

This PR adds three major features to suitecase:

1. **`fail` and `fail_now` functions** - Mark cases as failed with controlled behavior. `fail(msg)` records the failure and continues running remaining cases, while `fail_now(msg)` aborts all remaining cases after running teardown.

2. **Case selection and filtering** - Run single cases, groups of cases, or glob/regex patterns via `RunConfig::filter`, `RunConfig::filters`, `RunConfig::pattern`, or the CLI `--case` flag. Supports exact match, glob (`*`), and full regex patterns.

3. **Case dependencies (`depends_on`)** - Declare that a case requires other cases to run first. Dependencies are auto-included when filtering and run in topological order. Circular and missing dependencies panic at runtime.

## File changes

- Added `src/suite/fail.rs` - `FailReason` enum and panicking `fail`/`fail_now` functions
- Added `src/suite/fail_test.rs` - Tests for fail/fail_now behavior and interaction with dependencies
- Added `src/suite/selection_test.rs` - Tests for filtering, glob/regex patterns, dependencies, and fail/fail_now with deps
- Modified `src/suite/mod.rs` - Added `Case::dependencies`, `RunConfig::filters`/`pattern`/`from_args`, dependency resolution with cycle detection, topological sort, pattern matching (glob + regex), updated `cases!` macro for `depends_on` syntax
- Modified `src/lib.rs` - Re-exported `fail` and `fail_now` from crate root
- Modified `src/bin/suitecase/bin.rs` - Added `--case` CLI flag for filtering cases
- Modified `src/bin/suitecase/test.rs` - Pass `--case` through to test binary, removed GitHub Actions `::group::` markers so all tests remain visible in logs
- Modified `Cargo.toml` - Added `regex` dependency
- Modified `README.md` - Updated documentation with case selection, dependencies, fail/fail_now, and CLI filtering examples

This PR was used with Opencode and Qwen 3.6 plus